### PR TITLE
feature: Support named parameters in "quotes" rule

### DIFF
--- a/docs/description/description.json
+++ b/docs/description/description.json
@@ -2086,6 +2086,14 @@
       {
         "name": "unnamedParam",
         "description": "unnamedParam"
+      },
+      {
+        "name": "avoidEscape",
+        "description": "avoidEscape"
+      },
+      {
+        "name": "allowTemplateLiterals",
+        "description": "allowTemplateLiterals"
       }
     ]
   },

--- a/docs/patterns.json
+++ b/docs/patterns.json
@@ -1847,6 +1847,14 @@
         {
           "name": "unnamedParam",
           "default": "double"
+        },
+        {
+          "name": "avoidEscape",
+          "default": false
+        },
+        {
+          "name": "allowTemplateLiterals",
+          "default": false
         }
       ]
     },

--- a/src/rulesToUnnamedParametersDefaults.ts
+++ b/src/rulesToUnnamedParametersDefaults.ts
@@ -41,6 +41,8 @@ export const rulesToUnnamedParametersDefaults = new Map<string, any>([
 export class rulesNamedParametersAndDefaults {
   private static readonly array: [string, string, any][] = [
     ["padded-blocks", "allowSingleLineBlocks", true],
+    ["quotes", "avoidEscape", false],
+    ["quotes", "allowTemplateLiterals", false],
     ["react/display-name", "ignoreTranspilerName", false],
     ["sort-imports-es6-autofix/sort-imports-es6", "ignoreCase", false],
     ["sort-imports-es6-autofix/sort-imports-es6", "ignoreMemberSort", false],


### PR DESCRIPTION
- avoidEscape and allowTemplateLiterals parameters supported in the UI