### PR TITLE
fix: Change default config to consider sourceType as module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   codacy: codacy/base@2.3.0
-  codacy_plugins_test: codacy/plugins-test@0.11.0
+  codacy_plugins_test: codacy/plugins-test@0.13.0
 
 workflows:
   version: 2

--- a/docs/multiple-tests/json-file/patterns.xml
+++ b/docs/multiple-tests/json-file/patterns.xml
@@ -1,0 +1,25 @@
+<module name="root">
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="\.eslintrc\.json"/>
+    </module>
+    <module name="json_*" />
+    <module name="json_json" />
+    <module name="json_unknown" />
+    <module name="json_comment-not-permitted" />
+    <module name="json_undefined" />
+    <module name="json_enum-value-mismatch" />
+    <module name="json_unexpected-end-of-comment" />
+    <module name="json_unexpected-end-of-string" />
+    <module name="json_unexpected-end-of-number" />
+    <module name="json_invalid-unicode" />
+    <module name="json_invalid-escape-character" />
+    <module name="json_invalid-character" />
+    <module name="json_property-expected" />
+    <module name="json_comma-expected" />
+    <module name="json_colon-expected" />
+    <module name="json_value-expected" />
+    <module name="json_comma-or-close-backet-expected" />
+    <module name="json_comma-or-close-brace-expected" />
+    <module name="json_trailing-comma" />
+    <module name="json_duplicate-key" />
+</module>

--- a/docs/multiple-tests/json-file/results.xml
+++ b/docs/multiple-tests/json-file/results.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<checkstyle version="4.3">
+    <file name="test.json">
+        <error source="json_json" line="3" message="Comment not allowed" severity="info" />
+    </file>
+</checkstyle>

--- a/docs/multiple-tests/json-file/src/test.json
+++ b/docs/multiple-tests/json-file/src/test.json
@@ -1,0 +1,5 @@
+{
+  "test": 1,
+  // comment
+  "another_test": 2
+}

--- a/docs/multiple-tests/ts-import-without-config-file/patterns.xml
+++ b/docs/multiple-tests/ts-import-without-config-file/patterns.xml
@@ -1,0 +1,18 @@
+<module name="root">
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="tsconfig\.json"/>
+    </module>
+    <module name="@typescript-eslint_explicit-function-return-type" />
+    <module name="@typescript-eslint_no-unnecessary-boolean-literal-compare" />
+    <module name="@typescript-eslint_no-dupe-class-members" />
+    <module name="@typescript-eslint_no-dynamic-delete" />
+    <module name="@typescript-eslint_no-empty-function" />
+    <module name="@typescript-eslint_no-empty-interface" />
+    <module name="@typescript-eslint_no-explicit-any" />
+    <module name="@typescript-eslint_no-extra-non-null-assertion" />
+    <module name="@typescript-eslint_no-extra-parens" />
+    <module name="@typescript-eslint_no-extra-semi" />
+    <module name="@typescript-eslint_no-extraneous-class" />
+    <module name="@typescript-eslint_no-floating-promises" />
+    <module name="@typescript-eslint_no-for-in-array" />
+</module>

--- a/docs/multiple-tests/ts-import-without-config-file/results.xml
+++ b/docs/multiple-tests/ts-import-without-config-file/results.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<checkstyle version="4.3">
+    <file name="test.ts">
+        <error source="@typescript-eslint_explicit-function-return-type" line="4" message="Missing return type on function." severity="info" />
+    </file>
+</checkstyle>

--- a/docs/multiple-tests/ts-import-without-config-file/src/test.ts
+++ b/docs/multiple-tests/ts-import-without-config-file/src/test.ts
@@ -1,0 +1,6 @@
+import { A } from "module";
+
+
+export function test(){
+  console.log(A);
+}

--- a/docs/multiple-tests/tsconfig-relative-path/patterns.xml
+++ b/docs/multiple-tests/tsconfig-relative-path/patterns.xml
@@ -1,0 +1,5 @@
+<module name="root">
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="\.eslintrc\.json|tsconfig.json"/>
+    </module>
+</module>

--- a/docs/multiple-tests/typescript-with-config-file/src/.eslintrc.json
+++ b/docs/multiple-tests/typescript-with-config-file/src/.eslintrc.json
@@ -71,6 +71,7 @@
       "files": ["*.ts", "*.tsx"],
       "parser": "@typescript-eslint/parser",
       "parserOptions": {
+        "sourceType": "module",
         "ecmaFeatures": {
           "jsx": true
         }

--- a/src/configCreator.ts
+++ b/src/configCreator.ts
@@ -69,8 +69,12 @@ async function createOptions(
         )
         result.baseConfig.rules = patternsToRules(patterns)
         if (tsConfigFile) {
-          result.baseConfig.overrides[0].parserOptions = {
-            project: tsConfigFile,
+          if (result.baseConfig.overrides[0].parserOptions) {
+            result.baseConfig.overrides[0].parserOptions.project = tsConfigFile
+          } else {
+            result.baseConfig.overrides[0].parserOptions = {
+              project: tsConfigFile
+            }
           }
         }
       }

--- a/src/convertResults.ts
+++ b/src/convertResults.ts
@@ -11,12 +11,6 @@ export function convertResults(report: CLIEngine.LintReport): ToolResult[] {
     const messages = result.messages
     const fatalErrors = messages
       .filter((m) => m.fatal)
-      // this filter is here to avoid errors related to files not supported by current parser
-      // example: Using a "@typescript-eslint/parser" parser does not allow JSON files to be analyzed
-      .filter(
-        (m) =>
-          !m.message.includes("The file does not match your project config:")
-      )
       .map((m) => m.message)
     if (fatalErrors.length > 0) {
       results.push(new FileError(filename, fatalErrors.join("\\n")))

--- a/src/eslintDefaultOptions.ts
+++ b/src/eslintDefaultOptions.ts
@@ -76,6 +76,9 @@ export const defaultOptions: CLIEngine.Options = {
         files: ["**/*.ts", "**/*.tsx"],
         extends: baseConfigs.concat(typescriptConfigs),
         parser: "@typescript-eslint/parser",
+        parserOptions: {
+          sourceType: "module"
+        },
       },
     ],
     settings: {


### PR DESCRIPTION
This will accept module specific typescript syntax, such as import statements.
Added multiple tests for scenarios that could be affected (JSON, typescript with imports)

Fixes #558 