### PR TITLE
Add GitHub actions to import Jira tickets

### DIFF
--- a/.github/workflows/comment_issue.yml
+++ b/.github/workflows/comment_issue.yml
@@ -9,11 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
-
       - name: Jira Login
         id: login
         uses: atlassian/gajira-login@v2.0.0

--- a/.github/workflows/comment_issue.yml
+++ b/.github/workflows/comment_issue.yml
@@ -1,0 +1,40 @@
+name: Comment issue on Jira
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  jira:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Jira Login
+        id: login
+        uses: atlassian/gajira-login@v2.0.0
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+      - name: Extract Jira number
+        id: extract_jira_number
+        run: echo "::set-output name=jira_number::$(echo ${{ github.event.issue.title }}| sed 's/.*\[\(${{ secrets.JIRA_PROJECT }}-[[:digit:]]\{1,\}\)\].*/\1/')"
+
+      - name: Jira Add comment on issue
+        id: add_comment_jira_issue
+        uses: atlassian/gajira-comment@v2.0.0
+        with:
+          issue: ${{ steps.extract_jira_number.outputs.jira_number }}
+          comment: |
+            GitHub Comment : ${{ github.event.comment.user.login }}
+            {quote}${{ github.event.comment.body }}{quote}
+            ----
+            {panel}
+            _[Github permalink |${{ github.event.comment.html_url }}]_
+            {panel}

--- a/.github/workflows/create_issue.yml
+++ b/.github/workflows/create_issue.yml
@@ -9,11 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
-
       - name: Jira Login
         id: login
         uses: atlassian/gajira-login@v2.0.0

--- a/.github/workflows/create_issue.yml
+++ b/.github/workflows/create_issue.yml
@@ -1,0 +1,62 @@
+name: Create issue on Jira
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  jira:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Jira Login
+        id: login
+        uses: atlassian/gajira-login@v2.0.0
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+      - name: Jira Create issue
+        id: create_jira_issue
+        uses: atlassian/gajira-create@v2.0.0
+        with:
+          project: ${{ secrets.JIRA_PROJECT }}
+          issuetype: ${{ secrets.JIRA_ISSUE_TYPE }}
+          summary: "[GH#${{ github.event.issue.number }}]  ${{ github.event.issue.title }}"
+          description: |
+            ${{ github.event.issue.body }}
+            ----
+            {panel}
+            _[Github permalink |${{ github.event.issue.html_url }}]_
+            {panel}
+
+      - name: Change Title
+        uses: actions/github-script@v2.0.0
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title}}
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.update({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: '[${{ steps.create_jira_issue.outputs.issue }}] ${{ env.ISSUE_TITLE }}'
+            })
+      - name: Add comment after sync
+        uses: actions/github-script@v2.0.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Internal ticket created : [${{ steps.create_jira_issue.outputs.issue }}](${{ secrets.JIRA_BASE_URL }}/browse/${{ steps.create_jira_issue.outputs.issue }})'
+            })

--- a/.github/workflows/create_issue_on_label.yml
+++ b/.github/workflows/create_issue_on_label.yml
@@ -9,11 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
-
       - name: Jira Login
         id: login
         uses: atlassian/gajira-login@v2.0.0

--- a/.github/workflows/create_issue_on_label.yml
+++ b/.github/workflows/create_issue_on_label.yml
@@ -1,4 +1,4 @@
-name: Force creation of issue on Jira when labelled with force-jira-import
+name: Force creation of issue on Jira when labeled with force-jira-import
 
 on:
   issues:

--- a/.github/workflows/create_issue_on_label.yml
+++ b/.github/workflows/create_issue_on_label.yml
@@ -1,0 +1,62 @@
+name: Force creation of issue on Jira when labelled with force-jira-import
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  jira:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Jira Login
+        id: login
+        uses: atlassian/gajira-login@v2.0.0
+        env:
+          JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+
+      - name: Jira Create issue
+        id: create_jira_issue
+        uses: atlassian/gajira-create@v2.0.0
+        with:
+          project: ${{ secrets.JIRA_PROJECT }}
+          issuetype: ${{ secrets.JIRA_ISSUE_TYPE }}
+          summary: "[GH#${{ github.event.issue.number }}]  ${{ github.event.issue.title }}"
+          description: |
+            ${{ github.event.issue.body }}
+            ----
+            {panel}
+            _[Github permalink |${{ github.event.issue.html_url }}]_
+            {panel}
+
+      - name: Change Title
+        uses: actions/github-script@v2.0.0
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title}}
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.update({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: '[${{ steps.create_jira_issue.outputs.issue }}] ${{ env.ISSUE_TITLE }}'
+            })
+      - name: Add comment after sync
+        uses: actions/github-script@v2.0.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Internal ticket created : [${{ steps.create_jira_issue.outputs.issue }}](${{ secrets.JIRA_BASE_URL }}/browse/${{ steps.create_jira_issue.outputs.issue }})'
+            })


### PR DESCRIPTION
This allows for Jira tracking of the open issues by our community
The current actions will create the ticket, and comments on Jira,
it also relies on 'force-jira-import' label to force import tickets to Jira

Heavily based on work done at https://github.com/PierreLeresteux/JIRA_SYNC/tree/master/.github/workflows