### PR TITLE
test: Reproduction for bug CY-2866

### DIFF
--- a/docs/multiple-tests/ember_no-restricted-service-injections-no-parameters/patterns.xml
+++ b/docs/multiple-tests/ember_no-restricted-service-injections-no-parameters/patterns.xml
@@ -1,0 +1,3 @@
+<module name="root">
+    <module name="ember_no-restricted-service-injections" />
+</module>

--- a/docs/multiple-tests/ember_no-restricted-service-injections-no-parameters/results.xml
+++ b/docs/multiple-tests/ember_no-restricted-service-injections-no-parameters/results.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<checkstyle version="4.3"></checkstyle>

--- a/docs/multiple-tests/ember_no-restricted-service-injections-no-parameters/src/example.js
+++ b/docs/multiple-tests/ember_no-restricted-service-injections-no-parameters/src/example.js
@@ -1,0 +1,1 @@
+var s = 'A string';


### PR DESCRIPTION
codacy-eslint is not passing default values for parameters when they
are not passed to through the `/.codacyrc` file.
In this case, the tool should enrich the configuration by automatically
fetch the defaults stores in the `patterns.json`file.
This multiple-test should not fail and should give zero results.