### PR TITLE
Adds missing defaults from spec CY-2866

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   codacy: codacy/base@2.3.0
-  codacy_plugins_test: codacy/plugins-test@0.13.0
+  codacy_plugins_test: codacy/plugins-test@0.14.5
 
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /node_modules
 .metals
 /dist

--- a/README.md
+++ b/README.md
@@ -31,6 +31,28 @@ npm install
 npm run generateDocs
 ```
 
+## Test changes to codacy-seed locally
+You may need to test changes that comes from our [codacy-engine-typescript-seed](https://github.com/codacy/codacy-engine-typescript-seed).
+
+1.  Create a package with your changes on the seed:
+    * Don't forget to update the dependencies: `npm install`
+    * Compile the library: `npm run compile`
+    * Package the library: `npm pack`
+        > This should generate a codacy-seed-0.0.1.tgz on your codacy-seed repository
+
+2.  Copy the `codacy-seed-0.0.1.tgz` into the root of this repository
+
+3.  Install the package: `npm install codacy-seed-0.0.1.tgz`
+
+4.  Update Dockerfile and `.dockerignore` so you copy the `codacy-seed-0.0.1.tgz` inside the docker you will be building
+    *  Add `!codacy-seed-0.0.1.tgz` to your `.dockerignore`
+    *  Add the package to the docker before `RUN npm install`: `COPY codacy-seed-0.0.1.tgz ./`
+    *  Remove multi-stage docker steps
+        *  Lines from `FROM node:$NODE_IMAGE_VERSION` to `RUN rm -rf /package.json /package-lock.json`
+        > This way you skip copying the files to the other docker, and another `npm install`
+
+5.  Publish your docker locally as normal: `docker build -t codacy-eslint:local .`
+
 ## What is Codacy
 
 [Codacy](https://www.codacy.com/) is an Automated Code Review Tool that monitors your technical debt, helps you improve your code quality, teaches best practices to your developers, and helps you save time in Code Reviews.

--- a/docs/description/@typescript-eslint_ban-types.md
+++ b/docs/description/@typescript-eslint_ban-types.md
@@ -46,7 +46,7 @@ Example configuration:
     {
       "types": {
         // add a custom message to help explain why not to use it
-        "Foo": "Don't use Far because it is unsafe",
+        "Foo": "Don't use Foo because it is unsafe",
 
         // add a custom message, AND tell the plugin how to fix it
         "String": {

--- a/docs/description/@typescript-eslint_comma-dangle.md
+++ b/docs/description/@typescript-eslint_comma-dangle.md
@@ -1,0 +1,34 @@
+# Require or disallow trailing comma (`comma-dangle`)
+
+## Rule Details
+
+This rule extends the base [`eslint/comma-dangle`](https://eslint.org/docs/rules/comma-dangle) rule.
+It adds support for TypeScript syntax.
+
+See the [ESLint documentation](https://eslint.org/docs/rules/comma-dangle) for more details on the `comma-dangle` rule.
+
+## Rule Changes
+
+```cjson
+{
+  // note you must disable the base rule as it can report incorrect errors
+  "comma-dangle": "off",
+  "@typescript-eslint/comma-dangle": ["error"]
+}
+```
+
+In addition to the options supported by the `comma-dangle` rule in ESLint core, the rule adds the following options:
+
+## Options
+
+This rule has a string option and an object option.
+
+- Object option:
+
+  - `"enums"` is for trailing comma in enum. (e.g. `enum Foo = {Bar,}`)
+  - `"generics"` is for trailing comma in generic. (e.g. `function foo<T,>() {}`)
+  - `"tuples"` is for trailing comma in tuple. (e.g. `type Foo = [string,]`)
+
+- [See the other options allowed](https://github.com/eslint/eslint/blob/master/docs/rules/comma-dangle.md#options)
+
+<sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/comma-dangle.md)</sup>

--- a/docs/description/@typescript-eslint_consistent-type-definitions.md
+++ b/docs/description/@typescript-eslint_consistent-type-definitions.md
@@ -25,10 +25,10 @@ This rule accepts one string option:
 
 For example:
 
-```CJSON
+```jsonc
 {
-    // Use type for object definitions
-    "@typescript-eslint/consistent-type-definitions": ["error", "type"]
+  // Use type for object definitions
+  "@typescript-eslint/consistent-type-definitions": ["error", "type"]
 }
 ```
 

--- a/docs/description/@typescript-eslint_dot-notation.md
+++ b/docs/description/@typescript-eslint_dot-notation.md
@@ -7,7 +7,7 @@ It adds support for optionally ignoring computed `private` member access.
 
 ## How to use
 
-```cjson
+```jsonc
 {
   // note you must disable the base rule as it can report incorrect errors
   "dot-notation": "off",

--- a/docs/description/@typescript-eslint_explicit-function-return-type.md
+++ b/docs/description/@typescript-eslint_explicit-function-return-type.md
@@ -69,6 +69,8 @@ type Options = {
   allowTypedFunctionExpressions?: boolean;
   // if true, functions immediately returning another function expression will not be checked
   allowHigherOrderFunctions?: boolean;
+  // if true, arrow functions immediately returning a `as const` value will not be checked
+  allowDirectConstAssertionInArrowFunctions?: boolean;
   // if true, concise arrow functions that start with the void keyword will not be checked
   allowConciseArrowFunctionExpressionsStartingWithVoid?: boolean;
 };
@@ -77,6 +79,7 @@ const defaults = {
   allowExpressions: false,
   allowTypedFunctionExpressions: true,
   allowHigherOrderFunctions: true,
+  allowDirectConstAssertionInArrowFunctions: true,
   allowConciseArrowFunctionExpressionsStartingWithVoid: true,
 };
 ```
@@ -199,6 +202,22 @@ var arrowFn = () => (): void => {};
 function fn() {
   return function (): void {};
 }
+```
+
+### `allowDirectConstAssertionInArrowFunctions`
+
+Examples of **incorrect** code for this rule with `{ allowDirectConstAssertionInArrowFunctions: true }`:
+
+```ts
+const func = (value: number) => ({ type: 'X', value } as any);
+const func = (value: number) => ({ type: 'X', value } as Action);
+```
+
+Examples of **correct** code for this rule with `{ allowDirectConstAssertionInArrowFunctions: true }`:
+
+```ts
+const func = (value: number) => ({ foo: 'bar', value } as const);
+const func = () => x as const;
 ```
 
 ### `allowConciseArrowFunctionExpressionsStartingWithVoid`

--- a/docs/description/@typescript-eslint_explicit-member-accessibility.md
+++ b/docs/description/@typescript-eslint_explicit-member-accessibility.md
@@ -258,6 +258,10 @@ class Animal {
 class Animal {
   constructor(public animalName: string) {}
 }
+
+class Animal {
+  constructor(animalName: string) {}
+}
 ```
 
 e.g. `[ { accessibility: 'off', overrides: { parameterProperties: 'no-public' } } ]`

--- a/docs/description/@typescript-eslint_init-declarations.md
+++ b/docs/description/@typescript-eslint_init-declarations.md
@@ -7,7 +7,7 @@ It adds support for TypeScript's `declare` variables.
 
 ## How to use
 
-```cjson
+```jsonc
 {
   // note you must disable the base rule as it can report incorrect errors
   "init-declarations": "off",

--- a/docs/description/@typescript-eslint_keyword-spacing.md
+++ b/docs/description/@typescript-eslint_keyword-spacing.md
@@ -7,7 +7,7 @@ This version adds support for generic type parameters on function calls.
 
 ## How to use
 
-```cjson
+```jsonc
 {
   // note you must disable the base rule as it can report incorrect errors
   "keyword-spacing": "off",

--- a/docs/description/@typescript-eslint_lines-between-class-members.md
+++ b/docs/description/@typescript-eslint_lines-between-class-members.md
@@ -11,7 +11,7 @@ See the [ESLint documentation](https://eslint.org/docs/rules/lines-between-class
 
 ## Rule Changes
 
-```cjson
+```jsonc
 {
   // note you must disable the base rule as it can report incorrect errors
   "lines-between-class-members": "off",

--- a/docs/description/@typescript-eslint_no-empty-function.md
+++ b/docs/description/@typescript-eslint_no-empty-function.md
@@ -75,4 +75,16 @@ class Foo {
 }
 ```
 
+## How to use
+
+```jsonc
+{
+  // note you must disable the base rule as it can report incorrect errors
+  "no-empty-function": "off",
+  "@typescript-eslint/no-empty-function": ["error"]
+}
+```
+
+---
+
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/no-empty-function.md)</sup>

--- a/docs/description/@typescript-eslint_no-implied-eval.md
+++ b/docs/description/@typescript-eslint_no-implied-eval.md
@@ -88,6 +88,16 @@ class Foo {
 setTimeout(Foo.fn, 100);
 ```
 
+## How to use
+
+```jsonc
+{
+  // note you must disable the base rule as it can report incorrect errors
+  "no-implied-eval": "off",
+  "@typescript-eslint/no-implied-eval": ["error"]
+}
+```
+
 ## When Not To Use It
 
 If you want to allow `new Function()` or `setTimeout()`, `setInterval()`, `setImmediate()` and `execScript()` with string arguments, then you can safely disable this rule.

--- a/docs/description/@typescript-eslint_no-invalid-this.md
+++ b/docs/description/@typescript-eslint_no-invalid-this.md
@@ -7,7 +7,7 @@ It adds support for TypeScript's `this` parameters.
 
 ## How to use
 
-```cjson
+```jsonc
 {
   // note you must disable the base rule as it can report incorrect errors
   "no-invalid-this": "off",

--- a/docs/description/@typescript-eslint_no-invalid-void-type.md
+++ b/docs/description/@typescript-eslint_no-invalid-void-type.md
@@ -54,10 +54,12 @@ type stillVoid = void | never;
 ```ts
 interface Options {
   allowInGenericTypeArguments?: boolean | string[];
+  allowAsThisParameter?: boolean;
 }
 
 const defaultOptions: Options = {
   allowInGenericTypeArguments: true,
+  allowAsThisParameter: false,
 };
 ```
 
@@ -95,6 +97,23 @@ The following patterns are not considered warnings with `{ allowInGenericTypeArg
 ```ts
 type AllowedVoid = Ex.Mx.Tx<void>;
 type AllowedVoidUnion = void | Ex.Mx.Tx<void>;
+```
+
+#### `allowAsThisParameter`
+
+This option allows specifying a `this` parameter of a function to be `void` when set to `true`.
+This pattern can be useful to explicitly label function types that do not use a `this` argument. [See the TypeScript docs for more information](https://www.typescriptlang.org/docs/handbook/functions.html#this-parameters-in-callbacks).
+
+This option is `false` by default.
+
+The following patterns are considered warnings with `{ allowAsThisParameter: false }` but valid with `{ allowAsThisParameter: true }`:
+
+```ts
+function doThing(this: void) {}
+class Example {
+  static helper(this: void) {}
+  callback(this: void) {}
+}
 ```
 
 ## When Not To Use It

--- a/docs/description/@typescript-eslint_no-loop-func.md
+++ b/docs/description/@typescript-eslint_no-loop-func.md
@@ -7,7 +7,7 @@ It adds support for TypeScript types.
 
 ## How to use
 
-```cjson
+```jsonc
 {
   // note you must disable the base rule as it can report incorrect errors
   "no-loop-func": "off",

--- a/docs/description/@typescript-eslint_no-redeclare.md
+++ b/docs/description/@typescript-eslint_no-redeclare.md
@@ -21,12 +21,12 @@ See [`eslint/no-redeclare` options](https://eslint.org/docs/rules/no-redeclare#o
 This rule adds the following options:
 
 ```ts
-interface Options extends BaseNoShadowOptions {
+interface Options extends BaseNoRedeclareOptions {
   ignoreDeclarationMerge?: boolean;
 }
 
 const defaultOptions: Options = {
-  ...baseNoShadowDefaultOptions,
+  ...baseNoRedeclareDefaultOptions,
   ignoreDeclarationMerge: true,
 };
 ```

--- a/docs/description/@typescript-eslint_no-throw-literal.md
+++ b/docs/description/@typescript-eslint_no-throw-literal.md
@@ -79,6 +79,16 @@ class CustomError extends Error {
 throw new CustomError();
 ```
 
+## How to use
+
+```jsonc
+{
+  // note you must disable the base rule as it can report incorrect errors
+  "no-throw-literal": "off",
+  "@typescript-eslint/no-throw-literal": ["error"]
+}
+```
+
 ---
 
 <sup>Taken with ❤️ [from ESLint core](https://github.com/eslint/eslint/blob/master/docs/rules/no-throw-literal.md)</sup>

--- a/docs/description/@typescript-eslint_no-unsafe-member-access.md
+++ b/docs/description/@typescript-eslint_no-unsafe-member-access.md
@@ -35,11 +35,11 @@ Examples of **correct** code for this rule:
 ```ts
 declare const properlyTyped: { prop: { a: string } };
 
-nestedAny.prop.a;
-nestedAny.prop['a'];
+properlyTyped.prop.a;
+properlyTyped.prop['a'];
 
 const key = 'a';
-nestedAny.prop[key];
+properlyTyped.prop[key];
 
 const arr = [1, 2, 3];
 arr[1];

--- a/docs/description/@typescript-eslint_prefer-function-type.md
+++ b/docs/description/@typescript-eslint_prefer-function-type.md
@@ -24,6 +24,13 @@ interface Foo extends Function {
 }
 ```
 
+```ts
+interface MixinMethod {
+  // returns the function itself, not the `this` argument.
+  (arg: string): this;
+}
+```
+
 Examples of **correct** code for this rule:
 
 ```ts
@@ -46,6 +53,23 @@ interface Foo {
 interface Bar extends Foo {
   (): void;
 }
+```
+
+```ts
+// returns the `this` argument of function, retaining it's type.
+type MixinMethod = <TSelf>(this: TSelf, arg: string) => TSelf;
+// a function that returns itself is much clearer in this form.
+type ReturnsSelf = (arg: string) => ReturnsSelf;
+```
+
+```ts
+// multiple call signatures (overloads) is allowed:
+interface Overloaded {
+  (data: string): number;
+  (id: number): string;
+}
+// this is equivelent to Overloaded interface.
+type Intersection = ((data: string) => number) & ((id: number) => string);
 ```
 
 ## When Not To Use It

--- a/docs/description/@typescript-eslint_prefer-ts-expect-error.md
+++ b/docs/description/@typescript-eslint_prefer-ts-expect-error.md
@@ -1,6 +1,6 @@
-# Recommends using `// @ts-expect-error` over `// @ts-ignore` (`prefer-ts-expect-error`)
+# Recommends using `@ts-expect-error` over `@ts-ignore` (`prefer-ts-expect-error`)
 
-TypeScript allows you to suppress all errors on a line by placing a single-line comment starting with `@ts-ignore` immediately before the erroring line.
+TypeScript allows you to suppress all errors on a line by placing a single-line comment or a comment block line starting with `@ts-ignore` immediately before the erroring line.
 While powerful, there is no way to know if a `@ts-ignore` is actually suppressing an error without manually investigating what happens when the `@ts-ignore` is removed.
 
 This means its easy for `@ts-ignore`s to be forgotten about, and remain in code even after the error they were suppressing is fixed.
@@ -20,6 +20,15 @@ Examples of **incorrect** code for this rule:
 // @ts-ignore
 const str: string = 1;
 
+/**
+ * Explaining comment
+ *
+ * @ts-ignore */
+const multiLine: number = 'value';
+
+/** @ts-ignore */
+const block: string = 1;
+
 const isOptionEnabled = (key: string): boolean => {
   // @ts-ignore: if key isn't in globalOptions it'll be undefined which is false
   return !!globalOptions[key];
@@ -32,6 +41,15 @@ Examples of **correct** code for this rule:
 // @ts-expect-error
 const str: string = 1;
 
+/**
+ * Explaining comment
+ *
+ * @ts-expect-error */
+const multiLine: number = 'value';
+
+/** @ts-expect-error */
+const block: string = 1;
+
 const isOptionEnabled = (key: string): boolean => {
   // @ts-expect-error: if key isn't in globalOptions it'll be undefined which is false
   return !!globalOptions[key];
@@ -40,7 +58,7 @@ const isOptionEnabled = (key: string): boolean => {
 
 ## When Not To Use It
 
-If you are not using TypeScript 3.9 (or greater), then you will not be able to use this rule, as the directive is not supported
+If you are **NOT** using TypeScript 3.9 (or greater), then you will not be able to use this rule, as the directive is not supported
 
 ## Further Reading
 

--- a/docs/description/@typescript-eslint_return-await.md
+++ b/docs/description/@typescript-eslint_return-await.md
@@ -28,6 +28,12 @@ const defaultOptions: Options = 'in-try-catch';
 ### `in-try-catch`
 
 Requires that a returned promise must be `await`ed in `try-catch-finally` blocks, and disallows it elsewhere.
+Specifically:
+
+- if you `return` a promise within a `try`, then it must be `await`ed.
+- if you `return` a promise within a `catch`, and there **_is no_** `finally`, then it **_must not_** be `await`ed.
+- if you `return` a promise within a `catch`, and there **_is a_** `finally`, then it **_must_** be `await`ed.
+- if you `return` a promise within a `finally`, then it **_must not_** be `await`ed.
 
 Examples of **incorrect** code with `in-try-catch`:
 
@@ -39,10 +45,38 @@ async function invalidInTryCatch1() {
 }
 
 async function invalidInTryCatch2() {
-  return await Promise.resolve('try');
+  try {
+    throw new Error('error');
+  } catch (e) {
+    return await Promise.resolve('catch');
+  }
 }
 
 async function invalidInTryCatch3() {
+  try {
+    throw new Error('error');
+  } catch (e) {
+    return Promise.resolve('catch');
+  } finally {
+    console.log('cleanup');
+  }
+}
+
+async function invalidInTryCatch4() {
+  try {
+    throw new Error('error');
+  } catch (e) {
+    throw new Error('error2');
+  } finally {
+    return await Promise.resolve('finally');
+  }
+}
+
+async function invalidInTryCatch5() {
+  return await Promise.resolve('try');
+}
+
+async function invalidInTryCatch6() {
   return await 'value';
 }
 ```
@@ -57,10 +91,38 @@ async function validInTryCatch1() {
 }
 
 async function validInTryCatch2() {
-  return Promise.resolve('try');
+  try {
+    throw new Error('error');
+  } catch (e) {
+    return Promise.resolve('catch');
+  }
 }
 
 async function validInTryCatch3() {
+  try {
+    throw new Error('error');
+  } catch (e) {
+    return await Promise.resolve('catch');
+  } finally {
+    console.log('cleanup');
+  }
+}
+
+async function validInTryCatch4() {
+  try {
+    throw new Error('error');
+  } catch (e) {
+    throw new Error('error2');
+  } finally {
+    return Promise.resolve('finally');
+  }
+}
+
+async function validInTryCatch5() {
+  return Promise.resolve('try');
+}
+
+async function validInTryCatch6() {
   return 'value';
 }
 ```

--- a/docs/description/description.json
+++ b/docs/description/description.json
@@ -386,6 +386,10 @@
   {
     "parameters": [
       {
+        "name": "unnamedParam",
+        "description": "unnamedParam"
+      },
+      {
         "name": "allowArrowFunctions",
         "description": "allowArrowFunctions"
       }
@@ -4693,6 +4697,10 @@
       {
         "name": "catchEvents",
         "description": "catchEvents"
+      },
+      {
+        "name": "checkPlainGetters",
+        "description": "checkPlainGetters"
       }
     ],
     "patternId": "ember_no-side-effects",
@@ -4827,10 +4835,19 @@
     "timeToFix": 5
   },
   {
-    "parameters": [],
+    "parameters": [
+      {
+        "name": "checkInitOnly",
+        "description": "checkInitOnly"
+      },
+      {
+        "name": "checkNativeClasses",
+        "description": "checkNativeClasses"
+      }
+    ],
     "patternId": "ember_require-super-in-init",
     "title": "Ember: Require super in init",
-    "description": "Require `this._super` to be called in `init` hooks",
+    "description": "Require super to be called in lifecycle hooks",
     "timeToFix": 5
   },
   {
@@ -5777,6 +5794,13 @@
     "patternId": "jsdoc_check-indentation",
     "title": "Jsdoc: Check indentation",
     "description": "Reports invalid padding inside JSDoc blocks.",
+    "timeToFix": 5
+  },
+  {
+    "parameters": [],
+    "patternId": "jsdoc_check-line-alignment",
+    "title": "Jsdoc: Check line alignment",
+    "description": "Reports invalid alignment of JSDoc block lines.",
     "timeToFix": 5
   },
   {
@@ -8512,6 +8536,13 @@
     "timeToFix": 5
   },
   {
+    "parameters": [],
+    "patternId": "@typescript-eslint_comma-dangle",
+    "title": "@typescript eslint: Comma dangle",
+    "description": "Require or disallow trailing comma",
+    "timeToFix": 5
+  },
+  {
     "parameters": [
       {
         "name": "before",
@@ -9146,7 +9177,7 @@
     "parameters": [],
     "patternId": "@typescript-eslint_prefer-ts-expect-error",
     "title": "@typescript eslint: Prefer ts expect error",
-    "description": "Recommends using `// @ts-expect-error` over `// @ts-ignore`",
+    "description": "Recommends using `@ts-expect-error` over `@ts-ignore`",
     "timeToFix": 5
   },
   {

--- a/docs/description/ember_no-side-effects.md
+++ b/docs/description/ember_no-side-effects.md
@@ -47,3 +47,4 @@ export default Component.extend({
 This rule takes an optional object containing:
 
 * `boolean` -- `catchEvents` -- whether the rule should catch function calls that send actions or events (default `true`)
+* `boolean` -- `checkPlainGetters` -- whether the rule should check plain (non-computed) getters in native classes for side effects (default `false`, TODO: change default to `true` in next major release)

--- a/docs/description/ember_no-test-module-for.md
+++ b/docs/description/ember_no-test-module-for.md
@@ -11,12 +11,16 @@ Use `module` instead of `moduleFor`.
 Examples of **incorrect** code for this rule:
 
 ```js
+import { moduleFor } from 'ember-qunit';
+
 moduleFor('Test Name');
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
+import { module } from 'qunit';
+
 module('Test Name', function (hooks) {
   // ...
 });

--- a/docs/description/ember_require-super-in-init.md
+++ b/docs/description/ember_require-super-in-init.md
@@ -2,9 +2,13 @@
 
 :white_check_mark: The `"extends": "plugin:ember/recommended"` property in a configuration file enables this rule.
 
-Call `_super` in init lifecycle hooks.
+:wrench: The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems) can automatically fix some of the problems reported by this rule.
 
-When overriding the `init` lifecycle hook inside Ember Components, Controllers, Routes or Mixins, it is necessary to include a call to `_super`.
+Call super in lifecycle hooks.
+
+When overriding lifecycle hooks inside Ember Components, Controllers, Routes, Mixins, or Services, it is necessary to include a call to super.
+
+By default, this rule only applies to the `init` lifecycle hook and classic classes (see rule options to configure this).
 
 ## Examples
 
@@ -20,6 +24,28 @@ export default Component.extend({
 });
 ```
 
+```javascript
+// With: checkInitOnly = false
+import Component from '@ember/component';
+
+export default Component.extend({
+  didInsertElement() {
+    // ...
+  }
+});
+```
+
+```javascript
+// With: checkNativeClasses = true
+import Component from '@ember/component';
+
+class Foo extends Component {
+  init() {
+    // ...
+  }
+}
+```
+
 Examples of **correct** code for this rule:
 
 ```javascript
@@ -32,3 +58,43 @@ export default Component.extend({
   }
 });
 ```
+
+```javascript
+import Component from '@ember/component';
+
+export default Component.extend({
+  didInsertElement(...args) {
+    this._super(...args);
+    // ...
+  }
+});
+```
+
+```javascript
+import Component from '@ember/component';
+
+class Foo extends Component {
+  init(...args) {
+    super.init(...args);
+    // ...
+  }
+}
+```
+
+```javascript
+import Component from '@ember/component';
+
+class Foo extends Component {
+  didInsertElement(...args) {
+    super.didInsertElement(...args);
+    // ...
+  }
+}
+```
+
+## Configuration
+
+This rule takes an optional object containing:
+
+* `boolean` -- `checkInitOnly` -- whether the rule should only check the `init` lifecycle hook and not other lifecycle hooks (default `true`, TODO: change default to `false` and rename rule to `require-super-in-lifecycle-hooks` in next major release)
+* `boolean` -- `checkNativeClasses` -- whether the rule should check lifecycle hooks in native classes (in addition to classic classes) (default `false`, TODO: change default to `true` in next major release)

--- a/docs/description/lines-around-comment.md
+++ b/docs/description/lines-around-comment.md
@@ -437,7 +437,7 @@ const [
 
 ### ignorePattern
 
-By default this rule ignores comments starting with the following words: `eslint`, `jshint`, `jslint`, `istanbul`, `global`, `exported`, `jscs`. An alternative regular expression can be provided.
+By default this rule ignores comments starting with the following words: `eslint`, `jshint`, `jslint`, `istanbul`, `global`, `exported`, `jscs`. To ignore more comments in addition to the defaults, set the `ignorePattern` option to a string pattern that will be passed to the [`RegExp` constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/RegExp).
 
 Examples of **correct** code for the `ignorePattern` option:
 

--- a/docs/description/lines-between-class-members.md
+++ b/docs/description/lines-between-class-members.md
@@ -84,7 +84,7 @@ class Foo{
 Examples of **correct** code for this rule with the object option:
 
 ```js
-/* eslint lines-between-class-members: ["error", "always", { exceptAfterSingleLine: true }]*/
+/* eslint lines-between-class-members: ["error", "always", { "exceptAfterSingleLine": true }]*/
 class Foo{
   bar(){} // single line class member
   baz(){

--- a/docs/description/mocha_no-setup-in-describe.md
+++ b/docs/description/mocha_no-setup-in-describe.md
@@ -1,4 +1,3 @@
-
 # Disallow setup in describe blocks (no-setup-in-describe)
 
 Setup for test cases in mocha should be done in `before`, `beforeEach`, or `it` blocks. Unfortunately there is nothing stopping you from doing setup directly inside a `describe` block.

--- a/docs/description/no-inline-comments.md
+++ b/docs/description/no-inline-comments.md
@@ -87,3 +87,25 @@ var quux = (
     </div>
 )
 ```
+
+## Options
+
+### ignorePattern
+
+To make this rule ignore specific comments, set the `ignorePattern` option to a string pattern that will be passed to the [`RegExp` constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/RegExp).
+
+Examples of **correct** code for the `ignorePattern` option:
+
+```js
+/*eslint no-inline-comments: ["error", { "ignorePattern": "webpackChunkName:\\s.+" }]*/
+
+import(/* webpackChunkName: "my-chunk-name" */ './locale/en');
+```
+
+Examples of **incorrect** code for the `ignorePattern` option:
+
+```js
+/*eslint no-inline-comments: ["error", { "ignorePattern": "something" }] */
+
+var foo = 4; // other thing
+```

--- a/docs/description/prefer-destructuring.md
+++ b/docs/description/prefer-destructuring.md
@@ -21,6 +21,8 @@ The rule has a second object with a single key, `enforceForRenamedProperties`, w
 - Accessing an object property whose key is an integer will fall under the category `array` destructuring.
 - Accessing an array element through a computed index will fall under the category `object` destructuring.
 
+The `--fix` option on the command line fixes only problems reported in variable declarations, and among them only those that fall under the category `object` destructuring. Furthermore, the name of the declared variable has to be the same as the name used for non-computed member access in the initializer. For example, `var foo = object.foo` can be automatically fixed by this rule. Problems that involve computed member access (e.g., `var foo = object[foo]`) or renamed properties (e.g., `var foo = object.bar`) are not automatically fixed.
+
 Examples of **incorrect** code for this rule:
 
 ```javascript

--- a/docs/description/react_jsx-no-literals.md
+++ b/docs/description/react_jsx-no-literals.md
@@ -26,16 +26,17 @@ var Hello = <div>
 
 ## Rule Options
 
-There are two options:
+The supported options are:
 
 * `noStrings` (default: `false`) - Enforces no string literals used as children, wrapped or unwrapped.
 * `allowedStrings` - An array of unique string values that would otherwise warn, but will be ignored.
 * `ignoreProps` (default: `false`) - When `true` the rule ignores literals used in props, wrapped or unwrapped.
+* `noAttributeStrings` (default: `false`) - Enforces no string literals used in attributes when set to `true`.
 
 To use, you can specify as follows:
 
 ```js
-"react/jsx-no-literals": [<enabled>, {"noStrings": true, "allowedStrings": ["allowed"], "ignoreProps": false}]
+"react/jsx-no-literals": [<enabled>, {"noStrings": true, "allowedStrings": ["allowed"], "ignoreProps": false, "noAttributeStrings": true }]
 ```
 
 In this configuration, the following are considered warnings:
@@ -55,6 +56,12 @@ var Hello = <div>
 ```
 
 ```jsx
+var Hello = <div>
+<img alt="test"> </img>
+</div>;
+```
+
+```jsx
 var Hello = <div class='xx' />;
 ```
 
@@ -65,6 +72,7 @@ var Hello = <div class={'xx'} />;
 ```jsx
 var Hello = <div class={`xx`} />;
 ```
+
 
 
 The following are **not** considered warnings:
@@ -88,6 +96,13 @@ var Hello = <div>allowed</div>
 // an allowed string surrounded by only whitespace
 var Hello = <div>
   allowed
+</div>;
+```
+
+```jsx
+// a string value stored within a variable used as an attribute's value
+var Hello = <div>
+<img alt={imageDescription} {...props} />
 </div>;
 ```
 

--- a/docs/multiple-tests/ember_no-restricted-service-injections-no-parameters/patterns.xml
+++ b/docs/multiple-tests/ember_no-restricted-service-injections-no-parameters/patterns.xml
@@ -1,0 +1,3 @@
+<module name="root">
+    <module name="ember_no-restricted-service-injections" />
+</module>

--- a/docs/multiple-tests/ember_no-restricted-service-injections-no-parameters/results.xml
+++ b/docs/multiple-tests/ember_no-restricted-service-injections-no-parameters/results.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<checkstyle version="4.3"></checkstyle>

--- a/docs/multiple-tests/ember_no-restricted-service-injections-no-parameters/src/example.js
+++ b/docs/multiple-tests/ember_no-restricted-service-injections-no-parameters/src/example.js
@@ -1,0 +1,1 @@
+var s = 'A string';

--- a/docs/patterns.json
+++ b/docs/patterns.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint",
-  "version": "7.8.1",
+  "version": "7.10.0",
   "patterns": [
     {
       "patternId": "accessor-pairs",
@@ -391,6 +391,10 @@
       "level": "Info",
       "category": "CodeStyle",
       "parameters": [
+        {
+          "name": "unnamedParam",
+          "default": "expression"
+        },
         {
           "name": "allowArrowFunctions",
           "default": false
@@ -4871,6 +4875,10 @@
         {
           "name": "catchEvents",
           "default": true
+        },
+        {
+          "name": "checkPlainGetters",
+          "default": false
         }
       ],
       "enabled": true
@@ -5006,7 +5014,16 @@
       "patternId": "ember_require-super-in-init",
       "level": "Info",
       "category": "CodeStyle",
-      "parameters": [],
+      "parameters": [
+        {
+          "name": "checkInitOnly",
+          "default": true
+        },
+        {
+          "name": "checkNativeClasses",
+          "default": false
+        }
+      ],
       "enabled": true
     },
     {
@@ -6026,6 +6043,13 @@
     },
     {
       "patternId": "jsdoc_check-indentation",
+      "level": "Info",
+      "category": "CodeStyle",
+      "parameters": [],
+      "enabled": false
+    },
+    {
+      "patternId": "jsdoc_check-line-alignment",
       "level": "Info",
       "category": "CodeStyle",
       "parameters": [],
@@ -8990,6 +9014,13 @@
     },
     {
       "patternId": "@typescript-eslint_class-literal-property-style",
+      "level": "Info",
+      "category": "CodeStyle",
+      "parameters": [],
+      "enabled": false
+    },
+    {
+      "patternId": "@typescript-eslint_comma-dangle",
       "level": "Info",
       "category": "CodeStyle",
       "parameters": [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -4832,9 +4832,9 @@
       "integrity": "sha1-SwZYRrg2NhrabEtKSr9LwcrDG/E="
     },
     "codacy-seed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/codacy-seed/-/codacy-seed-1.2.0.tgz",
-      "integrity": "sha512-rXHx8RvHyQj2kaL+Ph5gqJQ+dmrgu2uujr7cb0qA8H+ms0QsmNnKlgKGiqQ0JQ5g7gVqgHEL11LUqVmB+WHxjw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/codacy-seed/-/codacy-seed-2.0.0.tgz",
+      "integrity": "sha512-wuJ2keK1bw+eBUXrsTWdW5v1LFQGBuY3SoBa69m1pH833nvnH8vU1PFv+qJq6tRGYpDwel81QDsl8Qf/F3KGyQ==",
       "requires": {
         "@nodelib/fs.walk": "^1.2.4",
         "node-fetch": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-plugin-transform-require-ignore": "^0.1.1",
-    "codacy-seed": "^1.2.0",
+    "codacy-seed": "^2.0.0",
     "eslint": "^7.10.0",
     "eslint-config-airbnb": "^18.2.0",
     "eslint-config-airbnb-base": "^14.2.0",

--- a/src/configCreator.ts
+++ b/src/configCreator.ts
@@ -21,12 +21,7 @@ function patternsToRules(
         namedParameters.map((p) => [p.name, p.value])
       )
 
-      // add default value if it is defined and not passed on the configuration
-      const unnamedOptions =
-        unnamedParameters.length === 0 &&
-        rulesToUnnamedParametersDefaults.has(patternId)
-          ? [rulesToUnnamedParametersDefaults.get(patternId)]
-          : unnamedParameters.map((p) => p.value)
+      const unnamedOptions = unnamedParameters.map((p) => p.value)
 
       return [
         patternId,
@@ -73,7 +68,7 @@ async function createOptions(
             result.baseConfig.overrides[0].parserOptions.project = tsConfigFile
           } else {
             result.baseConfig.overrides[0].parserOptions = {
-              project: tsConfigFile
+              project: tsConfigFile,
             }
           }
         }

--- a/src/docGenerator.ts
+++ b/src/docGenerator.ts
@@ -2,9 +2,9 @@ import {
   DescriptionEntry,
   DescriptionParameter,
   Level,
-  Patterns,
-  PatternsEntry,
-  PatternsParameter,
+  ParameterSpec,
+  PatternSpec,
+  Specification,
   writeFile,
 } from "codacy-seed"
 import { Rule } from "eslint"
@@ -35,7 +35,7 @@ export class DocGenerator {
   private generateParameters(
     patternId: string,
     schema: JSONSchema4 | JSONSchema4[] | undefined
-  ): PatternsParameter[] | undefined {
+  ): ParameterSpec[] | undefined {
     const namedParameters = schema
       ? this.fromEslintSchemaToParameters(patternId, schema)
       : undefined
@@ -43,9 +43,9 @@ export class DocGenerator {
       patternId
     )
     const unnamedParameter = unnamedParameterValue
-      ? new PatternsParameter("unnamedParam", unnamedParameterValue)
+      ? new ParameterSpec("unnamedParam", unnamedParameterValue)
       : undefined
-    function getParameters(): PatternsParameter[] | undefined {
+    function getParameters(): ParameterSpec[] | undefined {
       if (namedParameters && unnamedParameter)
         return [unnamedParameter, ...namedParameters]
       else if (namedParameters) return namedParameters
@@ -56,8 +56,8 @@ export class DocGenerator {
     return result && result.length > 0 ? result : undefined
   }
 
-  generatePatterns(): Patterns {
-    const entries = flatMap(this.rules, ([patternId, ruleModule]) => {
+  generatePatterns(): Specification {
+    const patterns = flatMap(this.rules, ([patternId, ruleModule]) => {
       const meta = ruleModule?.meta
       const eslintCategory = meta?.docs?.category
       const level: Level = fromEslintCategoryToLevel(eslintCategory)
@@ -67,7 +67,7 @@ export class DocGenerator {
       )
       const parameters = this.generateParameters(patternId, meta?.schema)
       const enabled = meta?.docs?.recommended === true
-      return new PatternsEntry(
+      return new PatternSpec(
         patternIdToCodacy(patternId),
         level,
         category,
@@ -77,7 +77,7 @@ export class DocGenerator {
       )
     })
 
-    return new Patterns(toolName, toolVersion, entries)
+    return new Specification(toolName, toolVersion, patterns)
   }
 
   generateDescriptionEntries(): DescriptionEntry[] {
@@ -111,7 +111,7 @@ export class DocGenerator {
   private fromEslintSchemaToParameters(
     patternId: string,
     schema: JSONSchema4 | JSONSchema4[]
-  ): PatternsParameter[] {
+  ): ParameterSpec[] {
     const anyOfToArray = (schema: JSONSchema4) =>
       schema.anyOf ? schema.anyOf : [schema]
 

--- a/src/namedParameters.ts
+++ b/src/namedParameters.ts
@@ -1,4 +1,4 @@
-import { PatternsParameter } from "codacy-seed"
+import { ParameterSpec } from "codacy-seed"
 import { JSONSchema4 } from "json-schema"
 import { flatMap, toPairs } from "lodash"
 
@@ -7,8 +7,8 @@ import { rulesNamedParametersAndDefaults } from "./rulesToUnnamedParametersDefau
 export function fromSchemaArray(
   patternId: string,
   objects: JSONSchema4[]
-): PatternsParameter[] {
-  return flatMap(objects, o => {
+): ParameterSpec[] {
+  return flatMap(objects, (o) => {
     const pairs = toPairs(o.properties)
     const haveDefault = pairs.filter(
       ([k, v]) => v && v.hasOwnProperty("default")
@@ -21,13 +21,13 @@ export function fromSchemaArray(
     )
     const a = pairs
       .filter(([k, v]) => v && !v.hasOwnProperty("default"))
-      .map(e => [patternId, e])
-    const automaticParameters: PatternsParameter[] = haveDefault.map(
-      ([k, v]) => new PatternsParameter(k, v.default)
+      .map((e) => [patternId, e])
+    const automaticParameters: ParameterSpec[] = haveDefault.map(
+      ([k, v]) => new ParameterSpec(k, v.default)
     )
-    const manualParameters: PatternsParameter[] = manual
+    const manualParameters: ParameterSpec[] = manual
       .map(([k, v]) => rulesNamedParametersAndDefaults.parameter(patternId, k))
-      .filter(e => e) as PatternsParameter[]
+      .filter((e) => e) as ParameterSpec[]
     return automaticParameters.concat(manualParameters)
   })
 }

--- a/src/rulesToUnnamedParametersDefaults.ts
+++ b/src/rulesToUnnamedParametersDefaults.ts
@@ -1,4 +1,4 @@
-import { PatternsParameter } from "codacy-seed"
+import { ParameterSpec } from "codacy-seed"
 
 export const rulesToUnnamedParametersDefaults = new Map<string, any>([
   ["array-bracket-spacing", "never"],
@@ -82,10 +82,10 @@ export class rulesNamedParametersAndDefaults {
   static parameter(
     patternId: string,
     parameter: string
-  ): PatternsParameter | undefined {
+  ): ParameterSpec | undefined {
     const e = this.array.find(
       ([pId, param, _]) => pId === patternId && param === parameter
     )
-    return e ? new PatternsParameter(parameter, e[2]) : undefined
+    return e ? new ParameterSpec(parameter, e[2]) : undefined
   }
 }

--- a/src/rulesToUnnamedParametersDefaults.ts
+++ b/src/rulesToUnnamedParametersDefaults.ts
@@ -14,6 +14,7 @@ export const rulesToUnnamedParametersDefaults = new Map<string, any>([
   ["eqeqeq", "smart"],
   ["filenames/match-exported", "camel"],
   ["filenames/match-regex", "^([a-z0-9]+)([A-Z][a-z0-9]+)*$"],
+  ["func-style", "expression"],
   ["id-match", "^[a-z]+([A-Z][a-z]+)*$"],
   ["indent", 2],
   ["jsx-quotes", "prefer-double"],

--- a/src/test/namedParameters.spec.ts
+++ b/src/test/namedParameters.spec.ts
@@ -1,5 +1,5 @@
 import { deepEqual } from "assert"
-import { PatternsParameter } from "codacy-seed"
+import { ParameterSpec } from "codacy-seed"
 import { JSONSchema4 } from "json-schema"
 
 import { fromSchemaArray } from "../namedParameters"
@@ -28,9 +28,9 @@ describe("namedParameters", () => {
         }
       ]
       const expectedResult = [
-        new PatternsParameter("getWithoutSet", false),
-        new PatternsParameter("setWithoutGet", true),
-        new PatternsParameter("enforceForClassMembers", false)
+        new ParameterSpec("getWithoutSet", false),
+        new ParameterSpec("setWithoutGet", true),
+        new ParameterSpec("enforceForClassMembers", false)
       ]
       deepEqual(fromSchemaArray("dummy", schemaArray), expectedResult)
     })


### PR DESCRIPTION
Bumps the codacy-seed version to now fetch the defaults from the specification (pattern.json)

Depends on https://github.com/codacy/codacy-engine-typescript-seed/pull/9