### PR TITLE
Add support of eslint-plugin-putout

### DIFF
--- a/docs/description/vue_attributes-order.md
+++ b/docs/description/vue_attributes-order.md
@@ -12,7 +12,7 @@ description: enforce order of attributes
 
 ## :book: Rule Details
 
-This rule aims to enforce ordering of component attributes. The default order is specified in the [Vue styleguide](https://v3.vuejs.org/style-guide/#element-attribute-order-recommended) and is:
+This rule aims to enforce ordering of component attributes. The default order is specified in the [Vue.js Style Guide](https://v3.vuejs.org/style-guide/#element-attribute-order-recommended) and is:
 
 - `DEFINITION`
   e.g. 'is', 'v-is'

--- a/docs/description/vue_match-component-file-name.md
+++ b/docs/description/vue_match-component-file-name.md
@@ -306,7 +306,7 @@ export default {
 
 ## :books: Further Reading
 
- - [Style guide - Single-file component filename casing](https://v3.vuejs.org/style-guide/#single-file-component-filename-casing-strongly-recommended)
+- [Style guide - Single-file component filename casing](https://v3.vuejs.org/style-guide/#single-file-component-filename-casing-strongly-recommended)
 
 ## :mag: Implementation
 

--- a/docs/description/vue_no-shared-component-data.md
+++ b/docs/description/vue_no-shared-component-data.md
@@ -68,7 +68,6 @@ Nothing.
 
 ## :books: Further Reading
 
-
 - [Style guide (for v2) - Component data](https://vuejs.org/v2/style-guide/#Component-data-essential)
 - [API - data](https://v3.vuejs.org/api/options-data.html#data-2)
 - [API (for v2) - data](https://v3.vuejs.org/api/options-data.html#data-2)

--- a/package-lock.json
+++ b/package-lock.json
@@ -624,6 +624,14 @@
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
+    "@babel/plugin-syntax-flow": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.10.4.tgz",
+      "integrity": "sha512-yxQsX1dJixF4qEEdzVbst3SZQ58Nrooz8NV9Z9GL4byTE25BvJgl5lf0RECUf0fh28rZBb/RYTWn/eeKwCMrZQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
     "@babel/plugin-syntax-import-meta": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
@@ -700,6 +708,14 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.10.4.tgz",
       "integrity": "sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-typescript": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.10.4.tgz",
+      "integrity": "sha512-oSAEz1YkBCAKr5Yiq8/BNtvSAPwkp/IyUnwZogd8p+F0RuYQQrLeRUzIQhueQTTBy/F+a40uS7OFKxnkRvmvFQ==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
       }
@@ -793,6 +809,15 @@
       "requires": {
         "@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
         "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-flow-strip-types": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.10.4.tgz",
+      "integrity": "sha512-XTadyuqNst88UWBTdLjM+wEY7BFnY2sYtPyAidfC7M/QaZnSuIZpMvLxqGT7phAcnGyWh/XQFLKcGf04CnvxSQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-flow": "^7.10.4"
       }
     },
     "@babel/plugin-transform-for-of": {
@@ -1052,6 +1077,16 @@
         "@babel/helper-plugin-utils": "^7.10.4"
       }
     },
+    "@babel/plugin-transform-typescript": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.11.0.tgz",
+      "integrity": "sha512-edJsNzTtvb3MaXQwj8403B7mZoGu9ElDJQZOKjGUnvilquxBA3IQoEIOvkX/1O8xfAsnHS/oQhe2w/IXrr+w0w==",
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.10.5",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-typescript": "^7.10.4"
+      }
+    },
     "@babel/plugin-transform-unicode-escapes": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.10.4.tgz",
@@ -1170,6 +1205,15 @@
         }
       }
     },
+    "@babel/preset-flow": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.10.4.tgz",
+      "integrity": "sha512-XI6l1CptQCOBv+ZKYwynyswhtOKwpZZp5n0LG1QKCo8erRhqjoQV6nvx61Eg30JHpysWQSBwA2AWRU3pBbSY5g==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-transform-flow-strip-types": "^7.10.4"
+      }
+    },
     "@babel/preset-modules": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
@@ -1194,6 +1238,27 @@
         "@babel/plugin-transform-react-jsx-self": "^7.10.4",
         "@babel/plugin-transform-react-jsx-source": "^7.10.4",
         "@babel/plugin-transform-react-pure-annotations": "^7.10.4"
+      }
+    },
+    "@babel/preset-typescript": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.10.4.tgz",
+      "integrity": "sha512-SdYnvGPv+bLlwkF2VkJnaX/ni1sMNetcGI1+nThF1gyv6Ph8Qucc4ZZAjM5yZcE/AKRXIOTZz7eSRDWOEjPyRQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-transform-typescript": "^7.10.4"
+      }
+    },
+    "@babel/register": {
+      "version": "7.11.5",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.11.5.tgz",
+      "integrity": "sha512-CAml0ioKX+kOAvBQDHa/+t1fgOt3qkTIz0TrRtRAT6XY0m5qYZXR85k6/sLCNPMGhYDlCFHCYuU0ybTJbvlC6w==",
+      "requires": {
+        "find-cache-dir": "^2.0.0",
+        "lodash": "^4.17.19",
+        "make-dir": "^2.1.0",
+        "pirates": "^4.0.0",
+        "source-map-support": "^0.5.16"
       }
     },
     "@babel/runtime": {
@@ -2151,6 +2216,947 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@prodigy/eslint-config-prodigy/-/eslint-config-prodigy-0.0.7.tgz",
       "integrity": "sha1-m9dULQ/i6W82a4kGWco7UrKFyZg="
+    },
+    "@putout/compare": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@putout/compare/-/compare-5.1.1.tgz",
+      "integrity": "sha512-xNRz9hY7SZPfc0VuKWcZCRcrEdfwBm5t/iDH83AkVlmKh2Hdd1I2yjoH+7GcBRCZuzYLg/2Vw/F3NRy4qS3RaA==",
+      "requires": {
+        "@babel/traverse": "^7.8.6",
+        "@babel/types": "^7.6.1",
+        "@putout/engine-parser": "^2.0.0",
+        "@putout/operate": "^5.0.0",
+        "debug": "^4.1.1",
+        "jessy": "^3.0.0",
+        "nessy": "^3.0.0"
+      }
+    },
+    "@putout/engine-loader": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@putout/engine-loader/-/engine-loader-2.1.2.tgz",
+      "integrity": "sha512-xHpqPVGrIEkMqc4rDHSdsAlDHW0XcnKrXlOOIBd3PfoyfPlbTDaxPyijcyaa3az1cWDbqrVDOEu7PrXzMeiIHw==",
+      "requires": {
+        "@babel/core": "^7.11.0",
+        "@putout/engine-parser": "^2.0.0",
+        "diff-match-patch": "^1.0.4",
+        "jscodeshift": "^0.10.0",
+        "nano-memoize": "^1.1.8",
+        "once": "^1.4.0",
+        "try-catch": "^3.0.0"
+      }
+    },
+    "@putout/engine-parser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/engine-parser/-/engine-parser-2.0.1.tgz",
+      "integrity": "sha512-Xhk6ACWUMig6ynWVLX6LBncFq/dNydP2FjsLwoVzBUSTNuVVsTrVdZCdB/mugIfKOu/iBm/lb53CHq1bYwRG5w==",
+      "requires": {
+        "@babel/generator": "^7.9.3",
+        "@babel/parser": "^7.9.3",
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.9.0",
+        "@putout/recast": "^1.1.0",
+        "estree-to-babel": "^3.0.0",
+        "nano-memoize": "^1.1.8",
+        "once": "^1.4.0"
+      }
+    },
+    "@putout/engine-runner": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@putout/engine-runner/-/engine-runner-8.2.0.tgz",
+      "integrity": "sha512-tPKS5VmdNF6dBzthwiIGDP7S01Q+RJ8eFzoxr8onPWdMzl1b+45TKVFZIBDTEH+cydyvjTmo22Vz8RFivGN1xQ==",
+      "requires": {
+        "@babel/traverse": "^7.6.2",
+        "@babel/types": "^7.6.1",
+        "@putout/compare": "^5.0.0",
+        "@putout/engine-parser": "^2.0.0",
+        "@putout/operate": "^5.0.0",
+        "debug": "^4.1.1",
+        "jessy": "^3.0.0",
+        "nessy": "^3.0.0",
+        "once": "^1.4.0",
+        "try-catch": "^3.0.0",
+        "wraptile": "^3.0.0"
+      }
+    },
+    "@putout/formatter-codeframe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@putout/formatter-codeframe/-/formatter-codeframe-2.0.3.tgz",
+      "integrity": "sha512-pEBlawJD9JczVHjRb1JyBXBXZnQD/Src0HiuBCO/W1H/ezHzhQTUsyFmqm+NAj8qnD6VimOKXZHdFPAcDv4Wtw==",
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@putout/formatter-json": "^1.0.0",
+        "chalk": "^4.0.0",
+        "table": "^6.0.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.5",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+          "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "astral-regex": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+          "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+          "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "table": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/table/-/table-6.0.3.tgz",
+          "integrity": "sha512-8321ZMcf1B9HvVX/btKv8mMZahCjn2aYrDlpqHaBFCfnox64edeH9kEid0vTLTRR8gWR2A20aDgeuTTea4sVtw==",
+          "requires": {
+            "ajv": "^6.12.4",
+            "lodash": "^4.17.20",
+            "slice-ansi": "^4.0.0",
+            "string-width": "^4.2.0"
+          }
+        }
+      }
+    },
+    "@putout/formatter-dump": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@putout/formatter-dump/-/formatter-dump-2.0.2.tgz",
+      "integrity": "sha512-2Tyms8z4Bt0adbVPojUMYItZ6hNUCkx6Y2EOdqq/KVo90Kdflr5EBeAQAwKCZ6L+E6BPxceOUwHxcH1UCDFrYw==",
+      "requires": {
+        "@putout/formatter-json": "^1.0.0",
+        "chalk": "^4.0.0",
+        "table": "^6.0.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.5",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+          "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "astral-regex": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+          "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+          "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "table": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/table/-/table-6.0.3.tgz",
+          "integrity": "sha512-8321ZMcf1B9HvVX/btKv8mMZahCjn2aYrDlpqHaBFCfnox64edeH9kEid0vTLTRR8gWR2A20aDgeuTTea4sVtw==",
+          "requires": {
+            "ajv": "^6.12.4",
+            "lodash": "^4.17.20",
+            "slice-ansi": "^4.0.0",
+            "string-width": "^4.2.0"
+          }
+        }
+      }
+    },
+    "@putout/formatter-frame": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@putout/formatter-frame/-/formatter-frame-1.0.2.tgz",
+      "integrity": "sha512-sTyDgdmkWOIfjiODt9QYFEm3nrf4cE4RiglrEKLoBnYjP8e3TTxwLVFpIYUGJPmowQZ9pQcsvCrbzBA4WM91zQ==",
+      "requires": {
+        "@putout/formatter-codeframe": "^2.0.1"
+      }
+    },
+    "@putout/formatter-json": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@putout/formatter-json/-/formatter-json-1.0.2.tgz",
+      "integrity": "sha512-grX6v60awcL6zOLKfVp2L+d6Suhr0c7mW71vksBV19m780CUvrzwOZ5B0wgjzqPpxr3wste1Q6CYvw5fjhyj2Q=="
+    },
+    "@putout/formatter-progress": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/formatter-progress/-/formatter-progress-2.1.0.tgz",
+      "integrity": "sha512-i6ZqDGr8q7z4EvoLZ2CbQMZqLY8b56e7nEu3hhbKb87B2HfTmullFZDijXzgmVf0N1vco+/ssFqb7geu8d2bMg==",
+      "requires": {
+        "@putout/formatter-dump": "^2.0.1"
+      }
+    },
+    "@putout/formatter-progress-bar": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@putout/formatter-progress-bar/-/formatter-progress-bar-1.1.1.tgz",
+      "integrity": "sha512-Y7OdEHzYy6bjVF1q3uxeCW62FYb1cW9ZJiRwNtk6YNikWKLlmgnxogvE5Jzxlbqe+/GWAq1u7c4xbQAPn9SUQQ==",
+      "requires": {
+        "@putout/formatter-dump": "^2.0.1",
+        "chalk": "^4.1.0",
+        "cli-progress": "^3.8.2",
+        "once": "^1.4.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@putout/formatter-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/formatter-stream/-/formatter-stream-2.0.1.tgz",
+      "integrity": "sha512-rsKW+1CLoCTi3qfxTjTTAkjgTGsRRE9sKa9hKyK6h55DnoNEtsvn9g/DrX/PxtfKT4lxNjNw/ayhX3PCsIaNdw==",
+      "requires": {
+        "chalk": "^4.0.0",
+        "table": "^6.0.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.5",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+          "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "astral-regex": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+          "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+          "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "table": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/table/-/table-6.0.3.tgz",
+          "integrity": "sha512-8321ZMcf1B9HvVX/btKv8mMZahCjn2aYrDlpqHaBFCfnox64edeH9kEid0vTLTRR8gWR2A20aDgeuTTea4sVtw==",
+          "requires": {
+            "ajv": "^6.12.4",
+            "lodash": "^4.17.20",
+            "slice-ansi": "^4.0.0",
+            "string-width": "^4.2.0"
+          }
+        }
+      }
+    },
+    "@putout/operate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/operate/-/operate-5.0.0.tgz",
+      "integrity": "sha512-NBH8TcQrD822v6fWt/BJ/ZnkDFMNCaUpPVLXast38v3OiADpyofgYvC3vvYqttNFtOEdgIm9mjnux4EACQMw1w==",
+      "requires": {
+        "@babel/types": "^7.6.3"
+      }
+    },
+    "@putout/plugin-add-return-await": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-add-return-await/-/plugin-add-return-await-2.1.0.tgz",
+      "integrity": "sha512-7pnaIwfsNIAjJFAgbOjh9bp57cQ0hfH6o/KgwCf8RqvtmADHD9EYy6wMd15bC3TrhB/Gl2FaFgtBSAj3m4gBtQ=="
+    },
+    "@putout/plugin-apply-destructuring": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-apply-destructuring/-/plugin-apply-destructuring-5.0.0.tgz",
+      "integrity": "sha512-hTlbuESeFNwJmev3S9kAoBVo+DEpTLMaV16MexeHmhaMw0LNla+qMEBYzZK11AC/xqVj7DbMfft2YpNc+SUoHg=="
+    },
+    "@putout/plugin-apply-nullish-coalescing": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-apply-nullish-coalescing/-/plugin-apply-nullish-coalescing-1.0.0.tgz",
+      "integrity": "sha512-8oNOzREx9cXaeRcVr2hN59PNcZ1Ymgty7eFpJ9x1bVjQcqjAikYGqaF8e1X2WWjcCJciiue//fNntLeC6OM0+Q=="
+    },
+    "@putout/plugin-apply-numeric-separators": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-apply-numeric-separators/-/plugin-apply-numeric-separators-1.0.2.tgz",
+      "integrity": "sha512-OaLATNYH00Qcx7gKF473Kvo9Q+jJjmakIoS33EManAuFZ8uBrPgZb53bA/fEoK7XvPhTpJf6cEPMdYtQdhF3HA=="
+    },
+    "@putout/plugin-apply-optional-chaining": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-apply-optional-chaining/-/plugin-apply-optional-chaining-2.0.1.tgz",
+      "integrity": "sha512-pdfnKABoiiDDsMCjTX0QzM8szH7OD3gbA3dA9SEqyjqOcut1/8lOpQsMTI3h8/m5FEnihpUFD2rNwFYUsj6p3Q=="
+    },
+    "@putout/plugin-apply-shorthand-properties": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-apply-shorthand-properties/-/plugin-apply-shorthand-properties-3.0.0.tgz",
+      "integrity": "sha512-/Jrs8RbqiWY+Q4HVUG7BbeGR9jqD4tdGDxlhwkuWn4cHsOGgVLSUCaQhlOgZJk+sp40WSyDe0B3VAH3rRQGB1g=="
+    },
+    "@putout/plugin-apply-top-level-await": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-apply-top-level-await/-/plugin-apply-top-level-await-2.0.1.tgz",
+      "integrity": "sha512-3+m4RYjI6Lv+fkclS71qb0y+0PNCdk+In4U17SM/nMYk4SbAxK5AV8ocdgsHcpHQjjPtkej1DRfH4eVgmidBWw==",
+      "requires": {
+        "fullstore": "^3.0.0"
+      }
+    },
+    "@putout/plugin-convert-apply-to-spread": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-apply-to-spread/-/plugin-convert-apply-to-spread-3.1.0.tgz",
+      "integrity": "sha512-fLu4oVSuUdXgn//ZDzF4Oe7kKc+fKbVmtJQetpa+OjLfmZ2Mwyu0yWqOpCAUpHSz/EHISd+V88465f/mW9pq4Q=="
+    },
+    "@putout/plugin-convert-arguments-to-rest": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-arguments-to-rest/-/plugin-convert-arguments-to-rest-1.2.0.tgz",
+      "integrity": "sha512-7iflDBpYKVshS3hGDnJiixoeEePmwIjd7cp3OEeB2WoU4agW6g90hywo8SrgUcy6RuOIdKmz+Z5aa2z+oReUqA=="
+    },
+    "@putout/plugin-convert-array-copy-to-slice": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-array-copy-to-slice/-/plugin-convert-array-copy-to-slice-1.0.2.tgz",
+      "integrity": "sha512-NTEqMhRgceDSxtTjYKgxQkNhu0gqajZ6+sOJ7hgvjSYrgj25UIJLzAyjdWmsRv67+Abs6+gWR2MI9BoLUDIZHQ=="
+    },
+    "@putout/plugin-convert-binary-expression-to-boolean": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-binary-expression-to-boolean/-/plugin-convert-binary-expression-to-boolean-2.1.0.tgz",
+      "integrity": "sha512-+OaQZLYBqHZRqb31s+8gIk1O06W9+Lpd9a0+VcK+yD+MAc3ofVMHplUssDbPAjK3jKWVG03I8PgQTH8BlSxWxA=="
+    },
+    "@putout/plugin-convert-commonjs-to-esm": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-commonjs-to-esm/-/plugin-convert-commonjs-to-esm-4.0.0.tgz",
+      "integrity": "sha512-ZQ442wpFXhEGC5olpRegLX/FHiKwkaPUjDT3NDxPc13Dc7nYTtx6M45ykjxOmAYYyNEBE3VdCXpGFOgLf7qpJg=="
+    },
+    "@putout/plugin-convert-equal-to-strict-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-equal-to-strict-equal/-/plugin-convert-equal-to-strict-equal-1.1.0.tgz",
+      "integrity": "sha512-H6H4Qu7lCBSyTj16olpB2D9PFH1owy08ORcFOfmvyvuLYDqJybyycMk4sHDvU4cQDhsHYfEGXJOeAaKnoxEtLA=="
+    },
+    "@putout/plugin-convert-esm-to-commonjs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-esm-to-commonjs/-/plugin-convert-esm-to-commonjs-3.0.0.tgz",
+      "integrity": "sha512-ZqnqRhLRla4tuI4qMBjJqiHUguNcd7OvXjb7OH1tl6fYgYdf5E+7KRlVXrWSBw+L8MWOd7X+cuslPCVVIZaLRA=="
+    },
+    "@putout/plugin-convert-for-each-to-for-of": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-for-each-to-for-of/-/plugin-convert-for-each-to-for-of-5.1.0.tgz",
+      "integrity": "sha512-x6OE2mNq7v72L/ASEHFWL1rQnKWmpDWkBfGrR9RrnsTjiJ8njeB85Q3RSas/kHh8a4j78cXOI2kJTh/T82h3Hw=="
+    },
+    "@putout/plugin-convert-for-in-to-for-of": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-for-in-to-for-of/-/plugin-convert-for-in-to-for-of-2.0.0.tgz",
+      "integrity": "sha512-uE9h/o30PMio2yP+YbaHWfce1n++5DyeuG05zHaaMIMX7/MkQM3B9nrWHp9u9TIdGqxTyu6J5AZ4cWwRRe9G3w=="
+    },
+    "@putout/plugin-convert-for-to-for-of": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-for-to-for-of/-/plugin-convert-for-to-for-of-1.2.1.tgz",
+      "integrity": "sha512-hTOU34OVL6y2Ov3Mge+glTwsHa/WUT5NHz1TusmlsA7aQQfh5N5AgL2OhRrLiBOiAG0Ex2QpSYbeFAajueVlHw=="
+    },
+    "@putout/plugin-convert-generic-to-shorthand": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-generic-to-shorthand/-/plugin-convert-generic-to-shorthand-1.0.0.tgz",
+      "integrity": "sha512-Yu79YHEMa+KwC8fPoUf4ntcXyqpXPvoVeArK0J2sqn2n+EdLfjgzMSX+seqChejG4KgfzB6JfcoDN0zVMY3kbQ=="
+    },
+    "@putout/plugin-convert-index-of-to-includes": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-index-of-to-includes/-/plugin-convert-index-of-to-includes-1.1.0.tgz",
+      "integrity": "sha512-d2w/GwYwtaq1ArW5VJA+CpSIPiRI1Lp4zJIGcQENj0zOyTwJ7OWP8SqHlqWOSoK6YpMoMFSDdlH1JU5NBTsx8Q=="
+    },
+    "@putout/plugin-convert-math-pow": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-math-pow/-/plugin-convert-math-pow-4.0.0.tgz",
+      "integrity": "sha512-KyIOdi0od8/AhDemjVeVSI2D1Mq8cIMdWiKAAawYdiYB+tUlGoKUnEkbg2XXdm5jt3gy5+bGodp806g8b16KHQ=="
+    },
+    "@putout/plugin-convert-object-assign-to-merge-spread": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-object-assign-to-merge-spread/-/plugin-convert-object-assign-to-merge-spread-4.0.1.tgz",
+      "integrity": "sha512-YnpydfRs1pzrOqy49LPIXkGIVPV9IsnT3ZLK8kzKDDXbNB4Xqc/ANS5Tzp7TK3FTRGBQYv/+c/1Pg+SyOgKQSg=="
+    },
+    "@putout/plugin-convert-template-to-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-template-to-string/-/plugin-convert-template-to-string-1.0.0.tgz",
+      "integrity": "sha512-Oh/MN4Irc6b3qafOSh3VQ+qw/DVZq2FSKt200XKpJw1HXcUk8RpPxNnG3xTpn2vTe/qK2e4VDtlLgdxUNo0onA=="
+    },
+    "@putout/plugin-convert-throw": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-throw/-/plugin-convert-throw-1.0.1.tgz",
+      "integrity": "sha512-osOeQ8UueD9hOko/v4UBd1tSf7xWSzHDDSsS5Dwg5cP6pGNwJ25as8hpqkgyWZXUxMJCuMdJ0p6lpRJfewRvoA=="
+    },
+    "@putout/plugin-convert-to-arrow-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-to-arrow-function/-/plugin-convert-to-arrow-function-2.0.0.tgz",
+      "integrity": "sha512-K3eWaUl8uJUrQoOSdyrL2qy8zqnbTrBa8/ODMc9d/h2k1kxWJnNUKUnTVoXvoVVWKLurG3Tx1K3vbN2hX0J9xQ=="
+    },
+    "@putout/plugin-convert-top-level-return": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-convert-top-level-return/-/plugin-convert-top-level-return-3.1.0.tgz",
+      "integrity": "sha512-L85ROIyrblODBtcCepvTXz241xE+uS89fQdOxJcSFa//FMeWapPWa6LhAQct6u/XH7XEnyYu0bTfAf5oB1ZZxA=="
+    },
+    "@putout/plugin-extract-object-properties": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-extract-object-properties/-/plugin-extract-object-properties-4.0.0.tgz",
+      "integrity": "sha512-z9Ny9efz1mVdpiOV2oXhm6iRVBPKSuOo8VYA9sRNyUm1t7vux025zlNVfS1OvlBC5rUPDfia0zLFyFNQBYGdFA=="
+    },
+    "@putout/plugin-extract-sequence-expressions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-extract-sequence-expressions/-/plugin-extract-sequence-expressions-2.1.0.tgz",
+      "integrity": "sha512-0FvhflynZsNIhN9K3irLopFBKQXnXuslZIEkp8G+n388prEHdQ0HZx3AEQJZAbB3cSEXyH5i8Alh2YDe1swl3Q=="
+    },
+    "@putout/plugin-madrun": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-madrun/-/plugin-madrun-7.0.0.tgz",
+      "integrity": "sha512-1W212WhG/GpDRLgaFulWBGNVnLF/flus0M81/S+dKJzJYUBA8i1HrGzZ8LnrzuGjLX81W2KxjMAzZT0qFlWOBg=="
+    },
+    "@putout/plugin-merge-destructuring-properties": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-merge-destructuring-properties/-/plugin-merge-destructuring-properties-5.0.0.tgz",
+      "integrity": "sha512-zd1AieTgqvgW1zr6a2LdxZ0DIxY9nzYBsybE55MGmwbmizuzIbhz51yjSkgQVlhF2g6O0oi+aLdrvE0/YE+AyA=="
+    },
+    "@putout/plugin-merge-duplicate-imports": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-merge-duplicate-imports/-/plugin-merge-duplicate-imports-3.0.0.tgz",
+      "integrity": "sha512-lwzY8H+FwGaoagYgS1K3Rjpw95jBsWnakuGN8z99v/V8VEVaX8PmszArPGJfC3R+Ew4+6GCxarFtD5dbp+ZXEA=="
+    },
+    "@putout/plugin-merge-if-statements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-merge-if-statements/-/plugin-merge-if-statements-3.0.0.tgz",
+      "integrity": "sha512-6U8wiUhDSqt1iub9OPcROh3DUg/L3D4uKeegziUg3pczcYxFw08t0yYbIXR317R4oiXBn4IjvB84quxTL0CH4Q=="
+    },
+    "@putout/plugin-promises": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-promises/-/plugin-promises-4.0.0.tgz",
+      "integrity": "sha512-jbD5fP0iFJ8WR8ynm9TMYaFjTAxWpaS9/BOEDP0ZH2FbEB5qJ6jljb0myoH8qhgoHWf6eENey/jCmlq2X2CMlw==",
+      "requires": {
+        "@putout/plugin-add-return-await": "^2.0.0"
+      }
+    },
+    "@putout/plugin-putout": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-putout/-/plugin-putout-5.1.3.tgz",
+      "integrity": "sha512-HjxquCK49/uwZIc8xXGnH9E4H1/94SExWnY76Zod0lD9wty4o7vtvazuXkUg+QKw8hXsbS5glwU287G+KxVN2w==",
+      "requires": {
+        "fullstore": "^3.0.0"
+      }
+    },
+    "@putout/plugin-remove-boolean-from-logical-expressions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-boolean-from-logical-expressions/-/plugin-remove-boolean-from-logical-expressions-2.0.1.tgz",
+      "integrity": "sha512-Q78nmRudwYW3kzvVxfIkgfsmMuQ8L5ptEMcAZ7OBY+Ex8zsFXCNaXygzWcQE5Qtq4rEWaSfwrvBH3hFGeUhpJw=="
+    },
+    "@putout/plugin-remove-console": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-console/-/plugin-remove-console-3.1.0.tgz",
+      "integrity": "sha512-sGBcfThKGNfLWBmXmjj3R2XJ3ONyBrPMuv3iL6xhMF5FhVCOqQGKier56eNroYnZCr0IlO/z/des2U2TSd8uHA=="
+    },
+    "@putout/plugin-remove-constant-conditions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-constant-conditions/-/plugin-remove-constant-conditions-2.0.0.tgz",
+      "integrity": "sha512-cVhlIyandoee+CgZhuxpsCT0bJiLwrCxOpIi14/fQSVZmr5DMZ8U81sp3jZq1/B7qCi0KKqcc0GbVQDw+Z3MlQ=="
+    },
+    "@putout/plugin-remove-debugger": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-debugger/-/plugin-remove-debugger-4.0.1.tgz",
+      "integrity": "sha512-XXSqLFmqkGMQIGwCa59RlhX2Fo1NO4FaABwzQTwpbMOUxpA+DBzyY2h9onShvSef/pS3BmTnR/j6mfBAIsURzA=="
+    },
+    "@putout/plugin-remove-double-negations": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-double-negations/-/plugin-remove-double-negations-2.0.0.tgz",
+      "integrity": "sha512-Wa5IYfEGK5golDvw2AMZscawekmEZ2aJhytTUygRar/UBjVvDEUAyKvuaKQ72oP48OkvocBQYHlsAoJwbjF0pA=="
+    },
+    "@putout/plugin-remove-duplicate-interface-keys": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-duplicate-interface-keys/-/plugin-remove-duplicate-interface-keys-2.0.1.tgz",
+      "integrity": "sha512-RzlgzBe6aW+adyVnxfxVu7bB8XmuPAWu79otzFBLCI8ufNZz7ZYtSNtipvQe5C8t1lsxYW0M8PM5QFNTKZY09Q=="
+    },
+    "@putout/plugin-remove-duplicate-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-duplicate-keys/-/plugin-remove-duplicate-keys-2.0.0.tgz",
+      "integrity": "sha512-3yBceS5LmKCJej9dJsqAiqqwDb4ZGpzLEj0UstmgcCFNq379I9pYHPIsjKSme0r10syO4tg7pSzIpymnRClkZg==",
+      "requires": {
+        "fullstore": "^3.0.0"
+      }
+    },
+    "@putout/plugin-remove-empty": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-empty/-/plugin-remove-empty-5.2.0.tgz",
+      "integrity": "sha512-hSpR7fecNZeInlrlcryixPqsxYG+fzBuMmTlYwT+u0i7FUbN4N70mFKiRxPrfsMVtTX9Xm6ZyBfQpHPREFvHmw==",
+      "requires": {
+        "@putout/plugin-remove-empty-pattern": "^3.0.1"
+      }
+    },
+    "@putout/plugin-remove-empty-pattern": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-empty-pattern/-/plugin-remove-empty-pattern-3.1.0.tgz",
+      "integrity": "sha512-ftx4gMFJ/4fOkRN9BbH73R5XZ95ZGHCzgjvPgr9ba/kPHWtAk7W1Qc8tt+OWZdeH6xj/F1/teiefnybbZ+IQ2w=="
+    },
+    "@putout/plugin-remove-nested-blocks": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-nested-blocks/-/plugin-remove-nested-blocks-3.0.0.tgz",
+      "integrity": "sha512-U262Or87Iq1BcVOJYHlT7Jy8JHfwVnz+5Q846XeBGg+HRJsg4NWSiNYsLLM409kahpZMlpyoQsoC9y0fhxuIxw=="
+    },
+    "@putout/plugin-remove-only": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-only/-/plugin-remove-only-4.1.0.tgz",
+      "integrity": "sha512-xh4tIjpTW3XiT3pJzl5tBN+C9Se2wc9Jk06YSJapRadwbL3VYj6lyX6GSfgR4Svc3JBhFr2QeQcOwOaIlWlP9A=="
+    },
+    "@putout/plugin-remove-process-exit": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-process-exit/-/plugin-remove-process-exit-3.0.0.tgz",
+      "integrity": "sha512-N6AEXDcvrsqwbA1CGJ/2TZg7a/Rix6lXP4Bs5IYHaN+8MzTvLO1BnowA6hmr7qKNZcp8iTpE6KCo1lqiUyldrw=="
+    },
+    "@putout/plugin-remove-skip": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-skip/-/plugin-remove-skip-3.1.0.tgz",
+      "integrity": "sha512-0HWbGYX/mZ7oXVvPXUcgXoMu3xZS5KSvHpD39Qbvq/IWzhwHQUUqTzy7FfbVG/qaLoXehXQ6beIKVhFKk3BCHQ=="
+    },
+    "@putout/plugin-remove-unreachable-code": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-unreachable-code/-/plugin-remove-unreachable-code-1.1.0.tgz",
+      "integrity": "sha512-eCjQtc8+kKBhLGo//ZHoQqvycTiPO2ARYinbzi6DdxPQlgo7lI08vHp4ow1Qo2J1CJrPqLuEgW0TCJ9H6OSsPg=="
+    },
+    "@putout/plugin-remove-unreferenced-variables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-unreferenced-variables/-/plugin-remove-unreferenced-variables-1.1.0.tgz",
+      "integrity": "sha512-Pg4MAbZaHhGmsl2QLfd5DUOiW6xlwRmxk+7UadpZT17yZsjeO2itM/DToX89d8i7lRMIKlQxqJ9uc4p/a1IufA=="
+    },
+    "@putout/plugin-remove-unused-expressions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-unused-expressions/-/plugin-remove-unused-expressions-2.0.0.tgz",
+      "integrity": "sha512-EjVFykKTKjEonOgQdGUONrFuEkyaDhCcqtKtbt+bPOiOKVhENYWAU9xJY6knIekc/oDZQfmjWZAL7KlG/BxxtQ=="
+    },
+    "@putout/plugin-remove-unused-for-of-variables": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-unused-for-of-variables/-/plugin-remove-unused-for-of-variables-1.2.0.tgz",
+      "integrity": "sha512-kicnGAk1bE+hRgR682YM3QIfuNT6MVVyRj2GPka8rb7ycMNV6iAInKlMhWRvdjNYp68Bxl6oYy7YbEnm+7a2cQ=="
+    },
+    "@putout/plugin-remove-unused-private-fields": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-unused-private-fields/-/plugin-remove-unused-private-fields-1.2.1.tgz",
+      "integrity": "sha512-aM+kBpMDDZz8JM4umuYXYEoMCuZRVx/QCmp+9d6cm6Ga2J1fT9cgol5F8DkcQLQFdDUddSNB4tb96GDcHgkpQw=="
+    },
+    "@putout/plugin-remove-unused-types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-unused-types/-/plugin-remove-unused-types-1.2.0.tgz",
+      "integrity": "sha512-4VR34L446RTz+1dQdF5m10hOqHbGNdah8kRf7/DVApmwiUTtfBNrv7ER8bNejJ52FtuLmjiAM8jcSLeSETMosA=="
+    },
+    "@putout/plugin-remove-unused-variables": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-unused-variables/-/plugin-remove-unused-variables-3.0.0.tgz",
+      "integrity": "sha512-PeRZshI7BttosGNlZojOYMjIkIjp7QF/smyl241DyOJD8fGOyD2INy/O5XE5FjLJ2NF6auLkVyRv7n/iXSlElA=="
+    },
+    "@putout/plugin-remove-useless-arguments": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-arguments/-/plugin-remove-useless-arguments-4.2.1.tgz",
+      "integrity": "sha512-rgS5vqUR404SURGUwKZ8GZpAY6jbtt4BT9CTtNrIVJGP+lvhE9zIb9OphfL16ptpC5+J6jnGVZti2qIGYE76oA=="
+    },
+    "@putout/plugin-remove-useless-array-from": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-array-from/-/plugin-remove-useless-array-from-2.1.0.tgz",
+      "integrity": "sha512-/iUlLKb/aAg9H4W8skl/hoFf3dLl0whMI5/PO30BVdTaY3VUVQnV35Gvp67HLNsqx3kM+8hxPBIdH8ZfQSH2Mg=="
+    },
+    "@putout/plugin-remove-useless-async": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-async/-/plugin-remove-useless-async-3.2.0.tgz",
+      "integrity": "sha512-lNkX0pwwnxJq7C8aYMuVVj2cGxJWVMrWErjbyaS6TvBt91KWE9SippDkCn/beNYwALDkpYCE7EJP28JZvNJAmg=="
+    },
+    "@putout/plugin-remove-useless-await": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-await/-/plugin-remove-useless-await-1.0.0.tgz",
+      "integrity": "sha512-fjNQ+pS6/0NFWEqIRzQpwEXN5aOD4OUxSJX5wPPCc7lv8LQsIOi7JJdrihLasP/vXiZwUkW7pz5s18kagxvqTA=="
+    },
+    "@putout/plugin-remove-useless-escape": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-escape/-/plugin-remove-useless-escape-1.1.1.tgz",
+      "integrity": "sha512-VlhuWEhBZ0fbmxGGOCUb9lFXHKWngaCphBAoGR9OGDAeKvjdUy1DfBX06DrA2twGnnxQ3rwn+5QYuTSuxjATTw=="
+    },
+    "@putout/plugin-remove-useless-for-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-for-of/-/plugin-remove-useless-for-of-1.0.1.tgz",
+      "integrity": "sha512-ndezn1obP7cTvZMyrdZsBwlQ6fduPK/oklqfR1KzoQNwhOX/6bEydDwwovne1tMkIyoktRx8B5u3rJ+ztBQ/2A=="
+    },
+    "@putout/plugin-remove-useless-functions": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-functions/-/plugin-remove-useless-functions-1.0.5.tgz",
+      "integrity": "sha512-bx35BmakBIHBJGYGbthLY077CytWKm0+xJ4CPD/xdQUSlPXdWvLsfUy+NEJ7aIQbD19qoMJpKGLju4oJGrCZNw=="
+    },
+    "@putout/plugin-remove-useless-spread": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-spread/-/plugin-remove-useless-spread-4.0.0.tgz",
+      "integrity": "sha512-jzJoWX+FVvMFQWreo/DDLf9rpcXbEHDX9JvCyO6CjVqrCwcIr3GvEhSgUb4j6X3ZjOBgtgklGSKZ2+rLFizj1Q=="
+    },
+    "@putout/plugin-remove-useless-template-expressions": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-template-expressions/-/plugin-remove-useless-template-expressions-1.0.1.tgz",
+      "integrity": "sha512-N/C//lQDusFo/MjxGMJuI1a7ccBaEKTjmh9xAL7dyMT+oH+9Qv0JagThul4mUYoXZqJH27TXWrPdHU2JzCpFBw=="
+    },
+    "@putout/plugin-remove-useless-typeof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-typeof/-/plugin-remove-useless-typeof-1.0.0.tgz",
+      "integrity": "sha512-C5nN1IwJeYhpqp7I2B4ki6jHhuc9cNAv0Z2DbTVE17J9HItsEShQgEyxGTxjGEb4dl2vOat2MHF70DbY6OFepg=="
+    },
+    "@putout/plugin-remove-useless-types": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-types/-/plugin-remove-useless-types-1.2.1.tgz",
+      "integrity": "sha512-cbGCML7TLudmpgnzY988XUrw4wcWoaNatYJaLAoPxCHrevUE7RGh8LsNouVaibjtVZYwf+IOd+Ya9eO+feMDCQ=="
+    },
+    "@putout/plugin-remove-useless-variables": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-remove-useless-variables/-/plugin-remove-useless-variables-4.3.0.tgz",
+      "integrity": "sha512-gjCTAxXPaQmjxwkb8Xp4FxeKKOOPEE8r5btHPPkNNrQqJpLj+Wyp5kR5sQ/cduW5REwF6ALWOM24FZ5mROmCZw=="
+    },
+    "@putout/plugin-reuse-duplicate-init": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-reuse-duplicate-init/-/plugin-reuse-duplicate-init-1.1.0.tgz",
+      "integrity": "sha512-i0TNiSflQUhq00SmJCGDBQIid2lZj8/tI49RYYBsBLqjAP6EpWQmmEOSJsLnXCoNGvst5NXkrQB66MhkWH6ajQ=="
+    },
+    "@putout/plugin-simplify-ternary": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-simplify-ternary/-/plugin-simplify-ternary-2.0.0.tgz",
+      "integrity": "sha512-dWAbAhBWC/FPjugG87DXWZYtuHunKI8zqBde8gSy8hW0AWcjntAaGIOzLLyavqXIaFcnN45olfl7PKHg4Hohug=="
+    },
+    "@putout/plugin-split-nested-destructuring": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-split-nested-destructuring/-/plugin-split-nested-destructuring-1.0.1.tgz",
+      "integrity": "sha512-myl/tM5b6zzIkqCcmnllX60uIhPbf1Npkh8znCYOKlmqzQvEr4L6pAImaSd8ChyXNnyvyVfNdhRNAAio9AKxMg=="
+    },
+    "@putout/plugin-split-variable-declarations": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-split-variable-declarations/-/plugin-split-variable-declarations-2.0.0.tgz",
+      "integrity": "sha512-rfxeVHNWkEivi3l2K/9abTVtBctBVNfGOBL4By87wny1isa5nqDl4NwkoFGlvdXVTcdSwNIaTkDyxjnU8vNJ4A=="
+    },
+    "@putout/plugin-strict-mode": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@putout/plugin-strict-mode/-/plugin-strict-mode-1.2.5.tgz",
+      "integrity": "sha512-THAMC9Cx71/w3uaAFDyaBrEAUmfqgS9J9hHpgH3gEigg0EnTejciKhsJHj5wZ2gcovW+/fNIvsAkhnSfZRq++Q==",
+      "requires": {
+        "fullstore": "^3.0.0"
+      }
+    },
+    "@putout/recast": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@putout/recast/-/recast-1.1.2.tgz",
+      "integrity": "sha512-KL2lzD/xverNGllgayMKXPu7afdgP/byV00Samw0wHXwDVyg7m69XIg48PWjOZrXxL0NZzU4Esr6TlKSWAge/Q==",
+      "requires": {
+        "ast-types": "0.14.1",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "tslib": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+          "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+        }
+      }
+    },
+    "@putout/traverse": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@putout/traverse/-/traverse-2.1.0.tgz",
+      "integrity": "sha512-uU9cTobOcWaJOVBDcs69ZqRNl88v5DGbZenwhdro0+ZNXJ56L32+DrDkmAq+4UOolxgt4fgxw7CT5Fm+iy9zqA==",
+      "requires": {
+        "@babel/traverse": "^7.8.6",
+        "@babel/types": "^7.9.0",
+        "@putout/compare": "^5.0.0"
+      }
     },
     "@react-native-community/eslint-config": {
       "version": "2.0.0",
@@ -3483,6 +4489,21 @@
       "resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.4.0.tgz",
       "integrity": "sha512-tKHdBe8N/Vq2nLAm4YPBVREVZjMux6KrqyPfNQgIbDl0t7HaNSmy8w4OyVHYg/cvyn5BW7o7pVwpjPte89Zhcg=="
     },
+    "ast-types": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.14.1.tgz",
+      "integrity": "sha512-pfSiukbt23P1qMhNnsozLzhMLBs7EEeXqPyvPmnuZM+RMfwfqwDbSVKYflgGuVI7/VehR4oMks0igzdNAg4VeQ==",
+      "requires": {
+        "tslib": "^2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+          "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+        }
+      }
+    },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -3503,6 +4524,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+    },
+    "async-lock": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.2.4.tgz",
+      "integrity": "sha512-UBQJC2pbeyGutIfYmErGc9RaJYnpZ1FHaxuKwb0ahvGiiCkPUf3p67Io+YLPmmv3RHY+mF6JEtNW8FlHsraAaA=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -4577,6 +5603,11 @@
         }
       }
     },
+    "clean-git-ref": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
+      "integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw=="
+    },
     "clean-stack": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.0.tgz",
@@ -4598,6 +5629,50 @@
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "requires": {
         "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-progress": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.8.2.tgz",
+      "integrity": "sha512-qRwBxLldMSfxB+YGFgNRaj5vyyHe1yMpVeDL79c+7puGujdKJHQHydgqXDcrkvQgJ5U/d3lpf6vffSoVVUftVQ==",
+      "requires": {
+        "colors": "^1.1.2",
+        "string-width": "^4.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "cli-truncate": {
@@ -4877,6 +5952,11 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
       "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw=="
     },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -5032,6 +6112,15 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
           "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
         }
+      }
+    },
+    "crc-32": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
+      "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
+      "requires": {
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.1.0"
       }
     },
     "create-ecdh": {
@@ -5245,6 +6334,11 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -5342,6 +6436,16 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true
+    },
+    "diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="
+    },
+    "diff3": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+      "integrity": "sha1-1OXDpM305f4SEatC5pP8tDIVgPw="
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -5574,6 +6678,14 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "error-stack-parser": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+      "requires": {
+        "stackframe": "^1.1.1"
       }
     },
     "es-abstract": {
@@ -9900,6 +11012,15 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
     },
+    "estree-to-babel": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-to-babel/-/estree-to-babel-3.0.0.tgz",
+      "integrity": "sha512-yOmbku+VGwgq5TNjqJSss4NQfdiolWV8vmf3EGHvHF7zbmlVmu0RdsaF6spNFqxgrz8ccjxeC1VVjnCbiGIweg==",
+      "requires": {
+        "@babel/traverse": "^7.1.6",
+        "@babel/types": "^7.2.0"
+      }
+    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -9956,6 +11077,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
       "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
+    },
+    "exit-on-epipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
+      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
     },
     "expand-brackets": {
       "version": "2.1.4",
@@ -10465,6 +11591,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
     },
+    "flow-parser": {
+      "version": "0.135.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.135.0.tgz",
+      "integrity": "sha512-ev8SvmG+XU9D6WgHVezP4kY3Myr1tJvTUTEi7mbhhj+rn889K7YXdakte6oqXNLIJYJ2f5Fuw18zXTVa1NO8Kw=="
+    },
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -10557,6 +11688,11 @@
         "bindings": "^1.5.0",
         "nan": "^2.12.1"
       }
+    },
+    "fullstore": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fullstore/-/fullstore-3.0.0.tgz",
+      "integrity": "sha512-EEIdG+HWpyygWRwSLIZy+x4u0xtghjHNfhQb0mI5825Mmjq6oFESFUY0hoZigEgd3KH8GX+ZOCK9wgmOiS7VBQ=="
     },
     "function-bind": {
       "version": "1.1.1",
@@ -11609,6 +12745,14 @@
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
       "dev": true
     },
+    "is-relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "requires": {
+        "is-unc-path": "^1.0.0"
+      }
+    },
     "is-resolvable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
@@ -11666,6 +12810,14 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
+    "is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "requires": {
+        "unc-path-regex": "^0.1.2"
+      }
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -11690,6 +12842,41 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
+    "isomorphic-git": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.7.8.tgz",
+      "integrity": "sha512-fSTsgp8J4s1aIfB/woR7slOAtX9wNprxs/iJaItE3yn5a/KjDAgIDcdutes88/0uC/VdCQFyuDZq1fdtYftrDw==",
+      "requires": {
+        "async-lock": "^1.1.0",
+        "clean-git-ref": "^2.0.1",
+        "crc-32": "^1.2.0",
+        "diff3": "0.0.3",
+        "ignore": "^5.1.4",
+        "minimisted": "^2.0.0",
+        "pako": "^1.0.10",
+        "pify": "^4.0.1",
+        "readable-stream": "^3.4.0",
+        "sha.js": "^2.4.9",
+        "simple-get": "^3.0.2"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -11741,6 +12928,11 @@
         "es-get-iterator": "^1.0.2",
         "iterate-iterator": "^1.0.1"
       }
+    },
+    "jessy": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/jessy/-/jessy-3.1.1.tgz",
+      "integrity": "sha512-Eivuwu3H8qfm4DldbyBci4RJMgoPK3pT3BCzIWNrGPOatkl4jh91PO4LZp7N2zIz8jQlYqs5bPKOkf138jRYqw=="
     },
     "jest-docblock": {
       "version": "21.2.0",
@@ -11995,6 +13187,49 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
+    "jscodeshift": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.10.0.tgz",
+      "integrity": "sha512-xpH2FVSEepXoNr6+cPlPHzPzBY1W9bPulufhCHOShzk8+CTCzAOQKytuOXT0b/9PvmO4biRi0g/ZIylVew815w==",
+      "requires": {
+        "@babel/core": "^7.1.6",
+        "@babel/parser": "^7.1.6",
+        "@babel/plugin-proposal-class-properties": "^7.1.0",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.1.0",
+        "@babel/plugin-proposal-optional-chaining": "^7.1.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.1.0",
+        "@babel/preset-flow": "^7.0.0",
+        "@babel/preset-typescript": "^7.1.0",
+        "@babel/register": "^7.0.0",
+        "babel-core": "^7.0.0-bridge.0",
+        "colors": "^1.1.2",
+        "flow-parser": "0.*",
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "neo-async": "^2.5.0",
+        "node-dir": "^0.1.17",
+        "recast": "^0.18.1",
+        "temp": "^0.8.1",
+        "write-file-atomic": "^2.3.0"
+      },
+      "dependencies": {
+        "babel-core": {
+          "version": "7.0.0-bridge.0",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
+          "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg=="
+        },
+        "write-file-atomic": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+          "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
+          }
+        }
+      }
+    },
     "jsdoctypeparser": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz",
@@ -12071,6 +13306,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
+    },
+    "json-stringify-deterministic": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-deterministic/-/json-stringify-deterministic-1.0.1.tgz",
+      "integrity": "sha512-9Fg0OY3uyzozpvJ8TVbUk09PjzhT7O2Q5kEe30g6OrKhbA/Is92igcx0XDDX7E3yAwnIlUcYLRl+ZkVrBYVP7A=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -13192,6 +14432,14 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
+    "minimisted": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
+      "integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
     "mississippi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
@@ -13550,6 +14798,11 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
       "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
     },
+    "nano-memoize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/nano-memoize/-/nano-memoize-1.2.0.tgz",
+      "integrity": "sha512-iNWfHsFJSXsGVqMXKS5RqdaEnQsWaxEApRmP3WdldI3NFqZTkQfmaZ28+U60/cAjEBK5AjFZZg5KwH9vhv+nvA=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -13583,6 +14836,11 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+    },
+    "nessy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/nessy/-/nessy-3.0.0.tgz",
+      "integrity": "sha512-CZFL/s2/jY76GTCASnHpwRoWIacFVH05IoHDodgJmC06BPrkai69T90/3hpXvZcIBL8eqZNmvvXmDgPHS9ALWQ=="
     },
     "netrc-parser": {
       "version": "3.1.6",
@@ -13644,6 +14902,14 @@
       "requires": {
         "lower-case": "^2.0.1",
         "tslib": "^1.10.0"
+      }
+    },
+    "node-dir": {
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
+      "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
+      "requires": {
+        "minimatch": "^3.0.2"
       }
     },
     "node-fetch": {
@@ -17471,6 +18737,11 @@
         "fast-diff": "^1.1.2"
       }
     },
+    "printj": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
+      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -17596,6 +18867,212 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "putout": {
+      "version": "10.0.5",
+      "resolved": "https://registry.npmjs.org/putout/-/putout-10.0.5.tgz",
+      "integrity": "sha512-4xidEEMkNBOOolHOknBkqhhOdHfbf4D5EheeyrlbIdbsCXreELIJX3ZTzF2IrDmg74fLTT7RUmM6g8B5WRYdUA==",
+      "requires": {
+        "@babel/code-frame": "^7.5.5",
+        "@babel/traverse": "^7.1.6",
+        "@babel/types": "^7.2.0",
+        "@putout/compare": "^5.0.0",
+        "@putout/engine-loader": "^2.0.0",
+        "@putout/engine-parser": "^2.0.0",
+        "@putout/engine-runner": "^8.0.0",
+        "@putout/formatter-codeframe": "^2.0.0",
+        "@putout/formatter-dump": "^2.0.0",
+        "@putout/formatter-frame": "^1.0.0",
+        "@putout/formatter-json": "^1.0.0",
+        "@putout/formatter-progress": "^2.0.0",
+        "@putout/formatter-progress-bar": "^1.1.0",
+        "@putout/formatter-stream": "^2.0.0",
+        "@putout/operate": "^5.0.0",
+        "@putout/plugin-apply-destructuring": "^5.0.0",
+        "@putout/plugin-apply-nullish-coalescing": "^1.0.0",
+        "@putout/plugin-apply-numeric-separators": "^1.0.0",
+        "@putout/plugin-apply-optional-chaining": "^2.0.0",
+        "@putout/plugin-apply-shorthand-properties": "^3.0.0",
+        "@putout/plugin-apply-top-level-await": "^2.0.0",
+        "@putout/plugin-convert-apply-to-spread": "^3.0.0",
+        "@putout/plugin-convert-arguments-to-rest": "^1.0.0",
+        "@putout/plugin-convert-array-copy-to-slice": "^1.0.0",
+        "@putout/plugin-convert-binary-expression-to-boolean": "^2.0.0",
+        "@putout/plugin-convert-commonjs-to-esm": "^4.0.0",
+        "@putout/plugin-convert-equal-to-strict-equal": "^1.0.0",
+        "@putout/plugin-convert-esm-to-commonjs": "^3.0.0",
+        "@putout/plugin-convert-for-each-to-for-of": "^5.0.0",
+        "@putout/plugin-convert-for-in-to-for-of": "^2.0.0",
+        "@putout/plugin-convert-for-to-for-of": "^1.0.0",
+        "@putout/plugin-convert-generic-to-shorthand": "^1.0.0",
+        "@putout/plugin-convert-index-of-to-includes": "^1.0.0",
+        "@putout/plugin-convert-math-pow": "^4.0.0",
+        "@putout/plugin-convert-object-assign-to-merge-spread": "^4.0.0",
+        "@putout/plugin-convert-template-to-string": "^1.0.0",
+        "@putout/plugin-convert-throw": "^1.0.0",
+        "@putout/plugin-convert-to-arrow-function": "^2.0.0",
+        "@putout/plugin-convert-top-level-return": "^3.0.0",
+        "@putout/plugin-extract-object-properties": "^4.0.0",
+        "@putout/plugin-extract-sequence-expressions": "^2.0.0",
+        "@putout/plugin-madrun": "^7.0.0",
+        "@putout/plugin-merge-destructuring-properties": "^5.0.0",
+        "@putout/plugin-merge-duplicate-imports": "^3.0.0",
+        "@putout/plugin-merge-if-statements": "^3.0.0",
+        "@putout/plugin-promises": "^4.0.0",
+        "@putout/plugin-putout": "^5.0.0",
+        "@putout/plugin-remove-boolean-from-logical-expressions": "^2.0.1",
+        "@putout/plugin-remove-console": "^3.0.0",
+        "@putout/plugin-remove-constant-conditions": "^2.0.0",
+        "@putout/plugin-remove-debugger": "^4.0.0",
+        "@putout/plugin-remove-double-negations": "^2.0.0",
+        "@putout/plugin-remove-duplicate-interface-keys": "^2.0.0",
+        "@putout/plugin-remove-duplicate-keys": "^2.0.0",
+        "@putout/plugin-remove-empty": "^5.0.0",
+        "@putout/plugin-remove-nested-blocks": "^3.0.0",
+        "@putout/plugin-remove-only": "^4.0.0",
+        "@putout/plugin-remove-process-exit": "^3.0.0",
+        "@putout/plugin-remove-skip": "^3.0.0",
+        "@putout/plugin-remove-unreachable-code": "^1.0.0",
+        "@putout/plugin-remove-unreferenced-variables": "^1.0.0",
+        "@putout/plugin-remove-unused-expressions": "^2.0.0",
+        "@putout/plugin-remove-unused-for-of-variables": "^1.0.0",
+        "@putout/plugin-remove-unused-private-fields": "^1.0.0",
+        "@putout/plugin-remove-unused-types": "^1.0.0",
+        "@putout/plugin-remove-unused-variables": "^3.0.0",
+        "@putout/plugin-remove-useless-arguments": "^4.0.0",
+        "@putout/plugin-remove-useless-array-from": "^2.0.0",
+        "@putout/plugin-remove-useless-async": "^3.0.0",
+        "@putout/plugin-remove-useless-await": "^1.0.0",
+        "@putout/plugin-remove-useless-escape": "^1.0.0",
+        "@putout/plugin-remove-useless-for-of": "^1.0.0",
+        "@putout/plugin-remove-useless-functions": "^1.0.3",
+        "@putout/plugin-remove-useless-spread": "^4.0.0",
+        "@putout/plugin-remove-useless-template-expressions": "^1.0.0",
+        "@putout/plugin-remove-useless-typeof": "^1.0.0",
+        "@putout/plugin-remove-useless-types": "^1.0.0",
+        "@putout/plugin-remove-useless-variables": "^4.0.0",
+        "@putout/plugin-reuse-duplicate-init": "^1.0.0",
+        "@putout/plugin-simplify-ternary": "^2.0.0",
+        "@putout/plugin-split-nested-destructuring": "^1.0.0",
+        "@putout/plugin-split-variable-declarations": "^2.0.0",
+        "@putout/plugin-strict-mode": "^1.0.0",
+        "@putout/traverse": "^2.0.0",
+        "array-union": "^2.0.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^2.0.0",
+        "debug": "^4.1.1",
+        "deepmerge": "^4.0.0",
+        "error-stack-parser": "^2.0.6",
+        "fast-glob": "^3.2.2",
+        "file-entry-cache": "^5.0.1",
+        "find-up": "^5.0.0",
+        "fullstore": "^3.0.0",
+        "ignore": "^5.0.4",
+        "imurmurhash": "^0.1.4",
+        "is-relative": "^1.0.0",
+        "isomorphic-git": "^1.4.0",
+        "json-stringify-deterministic": "^1.0.1",
+        "nano-memoize": "^1.1.11",
+        "once": "^1.4.0",
+        "try-catch": "^3.0.0",
+        "try-to-catch": "^3.0.0",
+        "tryrequire": "^3.0.0",
+        "yargs-parser": "^20.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
+          "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.1.tgz",
+          "integrity": "sha512-yYsjuSkjbLMBp16eaOt7/siKTjNVjMm3SoJnIg3sEh/JsvqVVDyjRKmaJV4cl+lNIgq6QEco2i3gDebJl7/vLA=="
+        }
+      }
     },
     "qs": {
       "version": "6.5.2",
@@ -17739,6 +19216,29 @@
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
           "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
+        }
+      }
+    },
+    "recast": {
+      "version": "0.18.10",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.18.10.tgz",
+      "integrity": "sha512-XNvYvkfdAN9QewbrxeTOjgINkdY/odTgTS56ZNEWL9Ml0weT4T3sFtvnTuF+Gxyu46ANcRm1ntrF6F5LAJPAaQ==",
+      "requires": {
+        "ast-types": "0.13.3",
+        "esprima": "~4.0.0",
+        "private": "^0.1.8",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "ast-types": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.3.tgz",
+          "integrity": "sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -18413,6 +19913,36 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+    },
+    "simple-get": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+      "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+      "requires": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      },
+      "dependencies": {
+        "decompress-response": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+          "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+          "requires": {
+            "mimic-response": "^2.0.0"
+          }
+        },
+        "mimic-response": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+          "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
+        }
+      }
+    },
     "simple-mock": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/simple-mock/-/simple-mock-0.8.0.tgz",
@@ -18718,6 +20248,11 @@
       "requires": {
         "figgy-pudding": "^3.5.1"
       }
+    },
+    "stackframe": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
+      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
     },
     "standard": {
       "version": "14.3.4",
@@ -19419,6 +20954,14 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
       "integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q="
     },
+    "temp": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.4.tgz",
+      "integrity": "sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==",
+      "requires": {
+        "rimraf": "~2.6.2"
+      }
+    },
     "terser": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
@@ -19603,6 +21146,24 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+    },
+    "try-catch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/try-catch/-/try-catch-3.0.0.tgz",
+      "integrity": "sha512-3uAqUnoemzca1ENvZ72EVimR+E8lqBbzwZ9v4CEbLjkaV3Q+FtdmPUt7jRtoSoTiYjyIMxEkf6YgUpe/voJ1ng=="
+    },
+    "try-to-catch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/try-to-catch/-/try-to-catch-3.0.0.tgz",
+      "integrity": "sha512-eIm6ZXwR35jVF8By/HdbbkcaCDTBI5PpCPkejRKrYp0jyf/DbCCcRhHD7/O9jtFI3ewsqo9WctFEiJTS6i+CQA=="
+    },
+    "tryrequire": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tryrequire/-/tryrequire-3.0.0.tgz",
+      "integrity": "sha512-4tWzmhveGrVFbfMzBXv2ow4QXWBQIkjDNNw/6YJzKgA4M70Jvu/MZghthvMptmV7DGtXDl2DvyE0pEw8ziRMnQ==",
+      "requires": {
+        "try-catch": "^3.0.0"
+      }
     },
     "ts-loader": {
       "version": "8.0.4",
@@ -19806,6 +21367,11 @@
       "requires": {
         "typescript-compare": "^0.0.2"
       }
+    },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -20624,6 +22190,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "wraptile": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/wraptile/-/wraptile-3.0.0.tgz",
+      "integrity": "sha512-23LJhkIw940uTcDFyJZmNyO0z8lEINOTGCr4vR5YCG3urkdXwduRIhivBm9wKaVynLHYvxoHHYbKsDiafCLp6w=="
     },
     "write": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
     "node-fetch": "^2.6.1",
     "npm": "^6.14.8",
     "prettier": "^2.1.2",
+    "putout": "^10.0.5",
     "redux-saga": "^1.1.3",
     "sort-package-json": "^1.46.0",
     "standard": "^14.3.4",


### PR DESCRIPTION
Added support of `eslint plugin` for code transformer [putout](https://github.com/coderaiser/putout) that fixes everything it can find according to best practices. It works mostly with code, not with formatting, so this is a great addition to `eslint` :). 

Right now linting of `putout` project is failing on `codacy`, because it doesn't support `eslint-plugin-putout`, but `putout` checks itself on every commit, has `100%` coverage, here is examples of checks:
- [github actions](https://github.com/coderaiser/putout/runs/1177535616)
- [sonarqube](https://github.com/coderaiser/putout/runs/1177539846)
- [travis](https://github.com/coderaiser/putout/runs/1177535494)

Would be amazing to add `codacy` to list of checkers :).