### PR TITLE
support usage of @vue/eslint-config-airbnb

### DIFF
--- a/docs/description/@typescript-eslint_naming-convention.md
+++ b/docs/description/@typescript-eslint_naming-convention.md
@@ -320,8 +320,8 @@ To clearly spell it out:
 
 - (3) is tested first because it has `types` and is an individual selector.
 - (2) is tested next because it is an individual selector.
-- (1) is tested next as it is a grouped selector.
-- (4) is tested last as it is the base default selector.
+- (4) is tested next as it is a grouped selector.
+- (1) is tested last as it is the base default selector.
 
 Its worth noting that whilst this order is applied, all selectors may not run on a name.
 This is explained in ["How does the rule evaluate a name's format?"](#how-does-the-rule-evaluate-a-names-format)

--- a/docs/description/description.json
+++ b/docs/description/description.json
@@ -4907,6 +4907,12 @@
   },
   {
     "parameters": [],
+    "patternId": "flowtype_object-type-curly-spacing",
+    "title": "Flowtype: Object type curly spacing",
+    "timeToFix": 5
+  },
+  {
+    "parameters": [],
     "patternId": "flowtype_object-type-delimiter",
     "title": "Flowtype: Object type delimiter",
     "timeToFix": 5

--- a/docs/description/meteor_audit-argument-checks.md
+++ b/docs/description/meteor_audit-argument-checks.md
@@ -41,14 +41,26 @@ Meteor.methods({
   }
 })
 
+Meteor.methods({
+  foo: function (bar) {
+    var ret;
+    ret = check(bar, Match.Any)
+  }
+})
+
 ```
+
+For a check function to be considered "called", it must be called at the
+top level of the method or publish function (not e.g. within an `if` block),
+either as a lone expression statement or as an assignment statement where the
+right-hand side is just the function call (as in the last example above).
 
 ### Options
 
 If you define your own functions that call `check`, you can provide a list of
 such functions via the configuration `checkEquivalents`.  This rule assumes
 that these functions effectively check their first argument (an identifier or
-a list of identifiers).
+an array of identifiers).
 
 For example, in `.eslintrc.json`, you can specify the following configuration:
 

--- a/docs/description/react_jsx-pascal-case.md
+++ b/docs/description/react_jsx-pascal-case.md
@@ -40,12 +40,13 @@ Examples of **correct** code for this rule:
 
 ```js
 ...
-"react/jsx-pascal-case": [<enabled>, { allowAllCaps: <allowAllCaps>, ignore: <ignore> }]
+"react/jsx-pascal-case": [<enabled>, { allowAllCaps: <allowAllCaps>, allowNamespace: <allowNamespace>, ignore: <ignore> }]
 ...
 ```
 
 * `enabled`: for enabling the rule. 0=off, 1=warn, 2=error. Defaults to 0.
 * `allowAllCaps`: optional boolean set to `true` to allow components name in all caps (default to `false`).
+* `allowNamespace`: optional boolean set to `true` to ignore namespaced components (default to `false`).
 * `ignore`: optional string-array of component names to ignore during validation (supports [minimatch](https://github.com/isaacs/minimatch)-style globs).
 
 ### `allowAllCaps`
@@ -55,6 +56,15 @@ Examples of **correct** code for this rule, when `allowAllCaps` is `true`:
 ```jsx
 <ALLOWED />
 <TEST_COMPONENT />
+```
+
+### `allowNamespace`
+
+Examples of **correct** code for this rule, when `allowNamespace` is `true`:
+
+```jsx
+<Allowed.div />
+<TestComponent.p />
 ```
 
 ## When Not To Use It

--- a/docs/patterns.json
+++ b/docs/patterns.json
@@ -5061,6 +5061,13 @@
       "enabled": false
     },
     {
+      "patternId": "flowtype_object-type-curly-spacing",
+      "level": "Info",
+      "category": "CodeStyle",
+      "parameters": [],
+      "enabled": false
+    },
+    {
       "patternId": "flowtype_object-type-delimiter",
       "level": "Info",
       "category": "CodeStyle",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5288,6 +5288,17 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
+    "@vue/eslint-config-airbnb": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@vue/eslint-config-airbnb/-/eslint-config-airbnb-5.3.0.tgz",
+      "integrity": "sha512-m9ldRhbqaODbcc9mQZjPgnTzyNweZblLMTqMfC2kHWY68dYd3kwG/hvENeZWXJnKKo+eGnoptk+7Zq/c1519ZQ==",
+      "requires": {
+        "eslint-config-airbnb-base": "^14.0.0",
+        "eslint-import-resolver-node": "^0.3.4",
+        "eslint-import-resolver-webpack": "^0.13.0",
+        "eslint-plugin-import": "^2.21.2"
+      }
+    },
     "@vue/eslint-config-prettier": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@vue/eslint-config-prettier/-/eslint-config-prettier-6.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -56,11 +56,11 @@
     "spec": "src/test/**/*.spec.ts"
   },
   "dependencies": {
-    "@angular-eslint/eslint-plugin": "^1.2.0",
     "@angular-eslint/builder": "^1.2.0",
-    "@angular-eslint/template-parser": "^1.2.0",
+    "@angular-eslint/eslint-plugin": "^1.2.0",
     "@angular-eslint/eslint-plugin-template": "^1.2.0",
     "@angular-eslint/schematics": "^1.2.0",
+    "@angular-eslint/template-parser": "^1.2.0",
     "@babel/cli": "^7.13.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.13.0",
     "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
@@ -79,6 +79,7 @@
     "@salesforce/eslint-config-lwc": "^0.9.0",
     "@typescript-eslint/eslint-plugin": "^4.15.2",
     "@typescript-eslint/parser": "^4.15.2",
+    "@vue/eslint-config-airbnb": "^5.3.0",
     "@vue/eslint-config-prettier": "^6.0.0",
     "@vue/eslint-config-typescript": "^7.0.0",
     "autoprefixer": "^9.8.6",

--- a/src/eslintDefaultOptions.ts
+++ b/src/eslintDefaultOptions.ts
@@ -23,7 +23,6 @@ export const defaultOptions: CLIEngine.Options = {
       qunit: true,
     },
     plugins: [
-      "airbnb",
       "angular",
       "angularjs-security-rules",
       "babel",
@@ -72,6 +71,7 @@ export const defaultOptions: CLIEngine.Options = {
       "standard",
       "@typescript-eslint",
       "vue",
+      "@vue/airbnb",
       "wdio",
       "xss",
     ],

--- a/src/eslintDefaultOptions.ts
+++ b/src/eslintDefaultOptions.ts
@@ -23,6 +23,7 @@ export const defaultOptions: CLIEngine.Options = {
       qunit: true,
     },
     plugins: [
+      "airbnb",
       "angular",
       "angularjs-security-rules",
       "babel",


### PR DESCRIPTION
Hey,

I've been testing Codacy to review it as our static code analysis tool but I noticed there was a lack of support for `@vue/eslint-config-airbnb` package, while I do understand that sometime this rulesets are very personal to a project, I would consider that this is a recommended setup coming from `@vue/cli`.

I tried to follow the instructions but might have missed something, especially how to test this addition
