### PR TITLE
feature: Increase v8 memory to try to improve on out of memory CY-3748

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ RUN chown -R docker:docker /docs
 
 WORKDIR /src
 
-CMD ["node", "/dist/src/index.js"]
+CMD ["node", "--max-old-space-size=2536", "/dist/src/index.js"]


### PR DESCRIPTION
The default is 512mb and for reference, the error returned in some cases:
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory

https://nodejs.org/api/cli.html#cli_max_old_space_size_size_in_megabytes

Not sure if this will solve the user problem, if it doesn't, I will revert it. Otherwise we can consider, maybe parametrising this?