### PR TITLE
Add support for expo eslint-config-universe

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "eslint-config-standard-react": "^11.0.1",
     "eslint-config-standard-with-typescript": "^20.0.0",
     "eslint-config-strongloop": "^2.1.0",
+    "eslint-config-universe": "^7.0.1",
     "eslint-config-vue": "^2.0.2",
     "eslint-config-winedirect": "^1.1.0",
     "eslint-config-xo": "^0.36.0",


### PR DESCRIPTION
This adds support for a popular eslint config present [eslint-config-universe](https://github.com/expo/expo/tree/master/packages/eslint-config-universe).