### PR TITLE
fix: Remove plugin that imposes import order CY-5143

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ COPY --from=builder docs docs
 
 RUN npm install --legacy-peer-deps --production
 
-RUN rm -rf /package.json /package-lock.json
+# Removing this plugin because it gets loaded by prettier and forces a fixed order for imports
+RUN rm -rf /package.json /package-lock.json /node_modules/prettier-plugin-organize-imports
 
 RUN adduser -u 2004 -D docker
 RUN chown -R docker:docker /docs

--- a/docs/multiple-tests/prettier-import/patterns.xml
+++ b/docs/multiple-tests/prettier-import/patterns.xml
@@ -1,0 +1,5 @@
+<module name="root">
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value=".*\.json" />
+    </module>
+</module>

--- a/docs/multiple-tests/prettier-import/results.xml
+++ b/docs/multiple-tests/prettier-import/results.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<checkstyle version="4.3">
+    <file name="example.ts">
+        <error source="prettier_prettier" line="5" message="Replace `&quot;33&quot;` with `'33';`" severity="info" />
+    </file>
+</checkstyle>

--- a/docs/multiple-tests/prettier-import/src/.eslintrc.json
+++ b/docs/multiple-tests/prettier-import/src/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["plugin:prettier/recommended"],
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint", "prettier"],
+  "rules": {
+    "prettier/prettier": "error"
+  }
+}

--- a/docs/multiple-tests/prettier-import/src/.prettierrc.json
+++ b/docs/multiple-tests/prettier-import/src/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 4,
+  "semi": true,
+  "singleQuote": true
+}

--- a/docs/multiple-tests/prettier-import/src/example.ts
+++ b/docs/multiple-tests/prettier-import/src/example.ts
@@ -1,0 +1,5 @@
+import { foo, bar } from 'foobar';
+export const foobar = foo + bar;
+
+var s = '33';
+var test = "33"


### PR DESCRIPTION
There's a plugin that depends on prettier-plugin-organize-imports that will be automatically loaded by prettier.
We removed the code directly from node_modules as a way to avoid removing the original dependency.