### PR TITLE
change: add debug messages to help when DEBUG=1 passed

### DIFF
--- a/src/configCreator.ts
+++ b/src/configCreator.ts
@@ -6,6 +6,7 @@ import { defaultOptions } from "./eslintDefaultOptions"
 import { patternIdToEslint } from "./model/patterns"
 import { rulesToUnnamedParametersDefaults } from "./rulesToUnnamedParametersDefaults"
 import { toolName } from "./toolMetadata"
+import {debug, debugEach, debugJson} from "./logging";
 
 function patternsToRules(
   patterns: Pattern[]
@@ -44,9 +45,16 @@ async function createOptions(
   if (codacyInput && codacyInput.tools) {
     const eslintTool = codacyInput.tools.find((tool) => tool.name === toolName)
     if (eslintTool && eslintTool.patterns) {
+      debug(`[codacy]: it appears we are going to use our own settings...`)
+      debug("[codacy]: read the following patterns to process from .codacyrc:")
+      debug(`[codacy]: # patterns to use: ${eslintTool.patterns.length}`)
+      debugEach(eslintTool.patterns, pattern => `[codacy]:  |- pattern name: ${pattern}`)
+
       const isTypescriptAnalysis =
         codacyInput.files &&
         codacyInput.files.every((f) => f.endsWith(".ts") || f.endsWith(".tsx"))
+
+      debug(`[codacy]: does the project appear to be a typescript one? - ${isTypescriptAnalysis}`)
 
       // typescript patterns require a typescript parser which will fail for different file types
       // so we are removing typescript patterns when analysing different file types
@@ -66,6 +74,8 @@ async function createOptions(
       //            check: conf file @ eslint-plugin-storybook/configs/recomneded.js
       const [storybookPatterns, otherPatterns] =
           partition(patterns, (p) => p.patternId.startsWith("storybook"))
+
+      debug(`[codacy]: do we have plugins to apply only to some file types? - ${storybookPatterns.length > 0}`)
 
       const result = cloneDeep(defaultOptions)
       if (result.baseConfig) {

--- a/src/engineImpl.ts
+++ b/src/engineImpl.ts
@@ -4,6 +4,7 @@ import { pathExists } from "fs-extra"
 
 import { configCreator } from "./configCreator"
 import { convertResults } from "./convertResults"
+import {debug, debugEach, debugJson, debugRun, debugWhen} from "./logging"
 
 export const engineImpl: Engine = async function (
   codacyrc?: Codacyrc
@@ -16,16 +17,29 @@ export const engineImpl: Engine = async function (
     (await pathExists(tsconfigFile)) ? tsconfigFile : undefined
   )
 
+  debug("[codacy]: calculated the following eslint config:")
+  debugJson(options, o => `[codacy]: ${o}`)
+  debug("[codacy]: read the following files to process from .codacyrc:")
+  debug(`[codacy]: # files to process: ${files.length}`)
+  debugEach(files, file => `[codacy]  |- filename: ${file}`)
+
   options.resolvePluginsRelativeTo = "/"
   options.cwd = srcDirPath
 
   const filesToAnalyze = files.length > 0 ? files : ["/src/**"]
+  debugWhen(!(files.length > 0), `[codacy]: decided to run tool for all files under /src`)
 
   const engine = new CLIEngine(options)
-
   const eslintResults = engine.executeOnFiles(filesToAnalyze)
 
-  const issues = convertResults(eslintResults)
+  debugRun(() => {
+    files.forEach(file => {
+      const configUsedOnSpecificFile = engine.getConfigForFile(file)
 
+      debugJson(configUsedOnSpecificFile, v => `[codacy] eslint config used for file="${file}":\n${v}`)
+    })
+  })
+
+  const issues = convertResults(eslintResults)
   return issues.map((r) => r.relativeTo(srcDirPath))
 }

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,0 +1,22 @@
+// logging utilities.
+// help print messages when environment variable DEBUG is passed to the docker.
+
+export function debug(msg: String) {
+    if (process.env.DEBUG) console.debug(msg)
+}
+
+export function debugEach<T>(arr: Array<T> | undefined, msg: (value: T) => String) {
+    if (process.env.DEBUG) arr?.forEach(value => console.debug(msg(value)))
+}
+
+export function debugJson(jsonObject: any, msg: (value: any) => String) {
+    if (process.env.DEBUG) console.log(msg(JSON.stringify(jsonObject, null, 2)))
+}
+
+export function debugWhen(cond: Boolean, msg: string) {
+    if (process.env.DEBUG && cond) console.log(msg)
+}
+
+export function debugRun<T>(fn: () => void) {
+    if (process.env.DEBUG) fn()
+}


### PR DESCRIPTION
This allow us to run the docker tool locally to try to
understand what's going on with the it.
Covers the main important points, specially what exactly
are the eslint settings being applied for each file since
eslint configuration resolution can be quite complex.

All the debug* functions are protected by verifying that DEBUG=1
so that none of the special code for debugging is run under normal
conditions. Just to make sure we don't degrade performance.

The docker can be run with:

docker run -e DEBUG=1 -v (pwd):/src:ro -v (pwd)/.codacyrc:/.codacyrc -it --rm codacy-eslint:latest

for example.