### PR TITLE
Add Create React App's Babel preset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "babel-plugin-lodash": "^3.3.4",
         "babel-plugin-module-resolver": "^4.1.0",
         "babel-plugin-transform-require-ignore": "^0.1.1",
+        "babel-preset-react-app": "^10.0.1",
         "codacy-seed": "^2.2.0",
         "confusing-browser-globals": "^1.0.11",
         "dotenv-webpack": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-module-resolver": "^4.1.0",
     "babel-plugin-transform-require-ignore": "^0.1.1",
+    "babel-preset-react-app": "^10.0.1",
     "codacy-seed": "^2.2.0",
     "confusing-browser-globals": "^1.0.11",
     "dotenv-webpack": "^7.1.0",


### PR DESCRIPTION
I'm requesting to add Create React App's Babel preset to Codacy.      
Codacy's ESLint scan is currently failing for our project due to this not being present. 