### PR TITLE
chore: update Dockerfile to reduce the image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG NODE_IMAGE_VERSION=16.13.0-alpine
 FROM node:$NODE_IMAGE_VERSION as builder
 
 COPY package*.json ./
-RUN npm install --legacy-peer-deps
+RUN npm install --legacy-peer-deps && npm cache clean --force;
 
 COPY . .
 
@@ -18,7 +18,7 @@ COPY --from=builder package.json ./
 COPY --from=builder package-lock.json ./
 COPY --from=builder docs docs
 
-RUN npm install --legacy-peer-deps --production
+RUN npm install --legacy-peer-deps --production && npm cache clean --force;
 
 # Removing this plugin because it gets loaded by prettier and forces a fixed order for imports
 RUN rm -rf /package.json /package-lock.json /node_modules/prettier-plugin-organize-imports


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size.

The change I made:
* I added `npm cache clean` after `npm install` to remove `npm` cache that is not needed inside the Docker image.


Impact on the image size:
* Image size before repair: 1.38 GB
* Image size after repair: 1.19 GB
* Difference: 195.24 MB (13.82%)

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.

Thanks,