### PR TITLE
fix: prevent await-thenable errors in tool

### DIFF
--- a/src/eslintDefaultOptions.ts
+++ b/src/eslintDefaultOptions.ts
@@ -37,7 +37,8 @@ export const defaultOptions: ESLint.Options = {
         parser: "@typescript-eslint/parser",
         parserOptions: {
           sourceType: "module",
-        },
+          project: "./tsconfig.json"
+        }
       },
       {
         files: ["./**/*.vue"],


### PR DESCRIPTION
error : 

Error: Error while loading rule '@typescript-eslint/await-thenable': You have used a rule which requires parserServices to be generated. You must therefore provide a value for the "parserOptions.project" property for @typescript-eslint/parser.