### PR TITLE
Revert "Add new configuration files"

### DIFF
--- a/src/configCreator.ts
+++ b/src/configCreator.ts
@@ -166,10 +166,7 @@ function existsEslintConfigInRepoRoot (srcDirPath: string): boolean {
     ".eslintrc.cjs",
     ".eslintrc.yaml",
     ".eslintrc.yml",
-    ".eslintrc.json",
-    "eslint.config.js",
-    "eslint.config.mjs",
-    "eslint.config.cjs"
+    ".eslintrc.json"
   ]
   const found = filenames.some(filename => existsSync(srcDirPath + path.sep + filename))
   debug(`options: eslintrc config file ${found ? "" : "not "}found`)


### PR DESCRIPTION
Reverts codacy/codacy-eslint#4459

Seems that this is not enough, as it is not workign for repos with the new config file, so better revert for now and check better later.