### PR TITLE
Add eslint-plugin-newline-destructuring

### DIFF
--- a/docs/description/description.json
+++ b/docs/description/description.json
@@ -13704,6 +13704,12 @@
     "timeToFix": 5
   },
   {
+    "parameters": [],
+    "patternId": "newline-destructuring_newline",
+    "title": "Newline destructuring: Newline",
+    "timeToFix": 5
+  },
+  {
     "parameters": [
       {
         "name": "block",

--- a/docs/multiple-tests/all-patterns-typescript/patterns.xml
+++ b/docs/multiple-tests/all-patterns-typescript/patterns.xml
@@ -1724,6 +1724,7 @@
   <module name="n_hashbang" />
   <module name="n_no-hide-core-modules" />
   <module name="n_shebang" />
+  <module name="newline-destructuring_newline" />
   <module name="no-only-tests_no-only-tests" />
   <module name="no-unsanitized_property" />
   <module name="no-unsanitized_method" />

--- a/docs/multiple-tests/all-patterns/patterns.xml
+++ b/docs/multiple-tests/all-patterns/patterns.xml
@@ -1724,6 +1724,7 @@
   <module name="n_hashbang" />
   <module name="n_no-hide-core-modules" />
   <module name="n_shebang" />
+  <module name="newline-destructuring_newline" />
   <module name="no-only-tests_no-only-tests" />
   <module name="no-unsanitized_property" />
   <module name="no-unsanitized_method" />

--- a/docs/multiple-tests/newline-destructuring/patterns.xml
+++ b/docs/multiple-tests/newline-destructuring/patterns.xml
@@ -1,0 +1,5 @@
+<module name="root">
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value=".*\.json" />
+    </module>
+</module>

--- a/docs/multiple-tests/newline-destructuring/results.xml
+++ b/docs/multiple-tests/newline-destructuring/results.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<checkstyle version="4.3">
+    <file name="newline-destructuring.js">
+        <error source="newline-destructuring_newline" line="2" message="Object desctructuring lines must be broken into multiple lines if there are more than 2 properties" severity="error" />
+    </file>
+</checkstyle>

--- a/docs/multiple-tests/newline-destructuring/results.xml
+++ b/docs/multiple-tests/newline-destructuring/results.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <checkstyle version="4.3">
     <file name="newline-destructuring.js">
-        <error source="newline-destructuring_newline" line="2" message="Object desctructuring lines must be broken into multiple lines if there are more than 2 properties" severity="error" />
+        <error source="newline-destructuring_newline" line="2" message="Object desctructuring lines must be broken into multiple lines if there are more than 2 properties" severity="info" />
     </file>
 </checkstyle>

--- a/docs/multiple-tests/newline-destructuring/src/.eslintrc.json
+++ b/docs/multiple-tests/newline-destructuring/src/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 2020
+  },
+  "plugins": ["newline-destructuring"],
+  "rules": {
+    "newline-destructuring/newline": ["error", { "items": 2 }]
+  }
+}

--- a/docs/multiple-tests/newline-destructuring/src/newline-destructuring.js
+++ b/docs/multiple-tests/newline-destructuring/src/newline-destructuring.js
@@ -1,0 +1,2 @@
+const obj = { a: 1, b: 2, c: 3 };
+const { a, b, c } = obj;

--- a/docs/patterns.json
+++ b/docs/patterns.json
@@ -13948,6 +13948,13 @@
       "enabled": false
     },
     {
+      "patternId": "newline-destructuring_newline",
+      "level": "Info",
+      "category": "CodeStyle",
+      "parameters": [],
+      "enabled": false
+    },
+    {
       "patternId": "no-only-tests_no-only-tests",
       "level": "Error",
       "category": "ErrorProne",

--- a/package-lock.json
+++ b/package-lock.json
@@ -233,6 +233,7 @@
         "eslint-plugin-mocha": "^10.4.3",
         "eslint-plugin-monorepo": "^0.3.2",
         "eslint-plugin-n": "^17.7.0",
+        "eslint-plugin-newline-destructuring": "^1.2.2",
         "eslint-plugin-no-only-tests": "^3.1.0",
         "eslint-plugin-no-unsanitized": "^4.0.2",
         "eslint-plugin-nuxt": "^4.0.0",
@@ -43388,6 +43389,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/eslint-plugin-newline-destructuring": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-newline-destructuring/-/eslint-plugin-newline-destructuring-1.2.2.tgz",
+      "integrity": "sha512-QfKQpdx+ez2E233B6xSG82+SdkKhxSchTJCjUHjJ2RmMCq+v2IBTaR8wK2pejTBV05p/J1qB8QOOKXQNqWJGSA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=7.2.0"
       }
     },
     "node_modules/eslint-plugin-no-only-tests": {

--- a/package.json
+++ b/package.json
@@ -290,6 +290,7 @@
     "eslint-plugin-mocha": "^10.4.3",
     "eslint-plugin-monorepo": "^0.3.2",
     "eslint-plugin-n": "^17.7.0",
+    "eslint-plugin-newline-destructuring": "^1.2.2",
     "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-no-unsanitized": "^4.0.2",
     "eslint-plugin-nuxt": "^4.0.0",

--- a/src/eslintPlugins.ts
+++ b/src/eslintPlugins.ts
@@ -72,6 +72,7 @@ const packageNames: string[] = [
   "eslint-plugin-mocha",
   "eslint-plugin-monorepo",
   "eslint-plugin-n",
+  "eslint-plugin-newline-destructuring",
   "eslint-plugin-no-only-tests",
   "eslint-plugin-no-unsanitized",
   "eslint-plugin-nuxt",


### PR DESCRIPTION
## Summary

- Add `eslint-plugin-newline-destructuring` as a dependency and register it in `src/eslintPlugins.ts`
- Regenerate docs so `newline-destructuring_newline` appears in `patterns.json` and `all-patterns`
- Add a multiple-test (`docs/multiple-tests/newline-destructuring/`) that enables the rule via `.eslintrc.json` and asserts the expected checkstyle output

## Test plan

- [ ] CI `plugins_test` passes (multiple-tests including `newline-destructuring`)
- [ ] Docker build succeeds